### PR TITLE
Improve case modals, state persistence, and action controls

### DIFF
--- a/assets/guc-casos.js
+++ b/assets/guc-casos.js
@@ -17,7 +17,7 @@
       $modal = $modal.detach().appendTo('body');
     }
 
-    // Modal "Inicio de caso" (reutilizado para Agregar acción)
+    // Modal "Inicio / Acción"
     let $startModal = $('#guc-modal-start');
     let $startForm  = $('#guc-form-inicio');
     const $startSave   = $('#guc-save-start');
@@ -27,43 +27,50 @@
       $startModal = $startModal.detach().appendTo('body');
     }
     $startModal.removeClass('show').attr('aria-hidden','true').hide();
-    // --- Dirty tracking for start modal ---
+
     let startDirty = false;
+    const START_TITLES = {
+      edit: 'Editar acción',
+      default: 'Registrar acción'
+    };
+
+    function setStartModalMode(mode){
+      const key = (mode === 'edit') ? 'edit' : 'default';
+      $startModal.attr('data-mode', key);
+      $startModal.find('.guc-modal-header h3').text(START_TITLES[key]);
+    }
+
+    function resetStartModal(){
+      startDirty = false;
+      $startModal.removeAttr('data-target-section data-edit-row data-mode');
+      if ($startForm[0]) {
+        $startForm[0].reset();
+      }
+    }
+
     $startForm.on('input change', 'input, textarea', function(){ startDirty = true; });
+
     function reallyCloseStart(){
       $startModal.removeClass('show').attr('aria-hidden','true').hide();
       $('body').removeClass('guc-no-scroll');
-      $startModal.removeAttr('data-target-section');
-      startDirty = false;
+      resetStartModal();
     }
+
     function closeStart(){
-      if (startDirty){
+      if (startDirty && $startModal.attr('data-mode') !== 'view'){
         if(!confirm('Tienes cambios sin guardar. ¿Cerrar de todos modos?')) return;
       }
       reallyCloseStart();
     }
-    $startModal.find('.guc-modal-close').off('click').on('click', closeStart);
 
-
-    function openStart(){ $startModal.addClass('show').attr('aria-hidden','false').show(); $('body').addClass('guc-no-scroll'); }
-    function closeStart(){ $startModal.removeClass('show').attr('aria-hidden','true').hide();
-    // --- Dirty tracking for start modal ---
-    let startDirty = false;
-    $startForm.on('input change', 'input, textarea', function(){ startDirty = true; });
-    function reallyCloseStart(){
-      $startModal.removeClass('show').attr('aria-hidden','true').hide();
-      $('body').removeClass('guc-no-scroll');
-      $startModal.removeAttr('data-target-section');
+    function openStart(mode){
+      setStartModalMode(mode);
       startDirty = false;
+      $startModal.addClass('show').attr('aria-hidden','false').show();
+      $('body').addClass('guc-no-scroll');
     }
-    function closeStart(){
-      if (startDirty){
-        if(!confirm('Tienes cambios sin guardar. ¿Cerrar de todos modos?')) return;
-      }
-      reallyCloseStart();
-    }
+
     $startModal.find('.guc-modal-close').off('click').on('click', closeStart);
- $('body').removeClass('guc-no-scroll'); $startModal.removeAttr('data-target-section'); }
     $startCancel.on('click', closeStart);
     $startModal.on('mousedown', function(e){
       const $dialog = $startModal.find('.guc-modal-dialog');
@@ -81,6 +88,9 @@
       if ($form[0]) $form[0].reset();
       $form.find('[name=id]').val('');
       $form.find('[name=entidad],[name=expediente]').val('');
+      $form.find('[name=case_type]').prop('disabled', false);
+      $form.find('input, textarea, select').prop('disabled', false).removeClass('guc-readonly');
+      $user.prop('disabled', false);
       setDirty(false);
     }
 
@@ -100,7 +110,15 @@
         m === 'create' ? 'Crear nuevo caso' :
         m === 'edit'   ? 'Editar caso'      : 'Ver caso'
       );
-      $form.find('input, textarea, select').prop('disabled', readonly).toggleClass('guc-readonly', readonly);
+      if (readonly) {
+        $form.find('input, textarea, select').prop('disabled', true).addClass('guc-readonly');
+      } else {
+        $form.find('input, textarea, select').prop('disabled', false).removeClass('guc-readonly');
+        const disableFixed = (m !== 'create');
+        $user.prop('disabled', disableFixed);
+        $form.find('[name=case_type]').prop('disabled', disableFixed);
+        $form.find('[name=entidad],[name=expediente]').prop('disabled', true).addClass('guc-readonly');
+      }
       $save.toggle(m !== 'view').text(m === 'edit' ? 'Actualizar' : 'Guardar');
     }
 
@@ -112,6 +130,7 @@
       $form.find('[name=entidad]').val(d.entidad || '');
       $form.find('[name=objeto]').val(d.objeto || '');
       $form.find('[name=descripcion]').val(d.descripcion || '');
+      $form.find('[name=case_type]').val(d.case_type || '');
       if ($user.length && d.user_id) $user.val(String(d.user_id));
     }
 
@@ -119,17 +138,36 @@
     /* =========================
      *  Helpers: state & UX
      * ========================= */
+    const STORAGE_KEY = 'gucCasosState';
+
+    function readStoredState(){
+      try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object') return parsed;
+      } catch(e){}
+      return null;
+    }
+
+    function rememberState(state){
+      try {
+        if (state) {
+          window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+        }
+      } catch(e){}
+    }
+
     function captureState(){
       const state = { openCases: [], panels:{}, secretariaBucket:{} };
       $('tr.guc-subrow').each(function(){
-        const caseId = $(this).attr('data-parent');
+        const caseId = String($(this).attr('data-parent') || '');
         if(!caseId) return;
-        state.openCases.push(caseId);
+        if (!state.openCases.includes(caseId)) state.openCases.push(caseId);
         state.panels[caseId] = [];
         $(this).find('.guc-sec .guc-toggle').each(function(idx){
           state.panels[caseId][idx] = ($(this).attr('aria-expanded') === 'true');
         });
-        // record current secretaria bucket if present
         const $secWrap = $(this).find('.guc-subtable-wrap[data-section="secretaria"]');
         const b = $secWrap.attr('data-bucket');
         if (b) state.secretariaBucket[caseId] = b;
@@ -137,43 +175,91 @@
       return state;
     }
 
-    function restoreState(state){
-      if(!state || !state.openCases) return;
-      state.openCases.forEach(function(caseId){
-        const $row = $('.guc-start[data-id="'+caseId+'"]').first().closest('tr');
-        if(!$row.length) return;
-        const $sub = ensureSubrow($row, caseId);
-        // restore secretaria bucket/title if remembered
-        if (state.secretariaBucket[caseId]) {
-          const b = state.secretariaBucket[caseId];
-          const $wrap = $sub.find('.guc-subtable-wrap[data-section="secretaria"]');
-          $wrap.attr('data-bucket', b);
-          $sub.find('[data-secretaria-title]').text(b === 'sec_arbitral' ? 'Secretaría Arbitral' : 'Secretaría General');
-        }
-        // render all wraps
-        $sub.find('.guc-subtable-wrap').each(function(){ renderSection($(this)); });
-
-        // restore panel expanded/collapsed
-        const arr = state.panels[caseId] || [];
-        $sub.find('.guc-sec .guc-toggle').each(function(idx){
-          const wantOpen = (arr[idx] !== false); // default open
-          const $btn = $(this);
-          const $panel = $btn.next('.guc-panel');
-          $btn.attr('aria-expanded', wantOpen ? 'true' : 'false');
-          $btn.find('.guc-caret').text(wantOpen ? '▴' : '▾');
-          if (wantOpen) $panel.show(); else $panel.hide();
-        });
+    function applyPanelState($sub, arr){
+      const cfg = arr || [];
+      $sub.find('.guc-sec .guc-toggle').each(function(idx){
+        const wantOpen = (cfg[idx] !== false);
+        const $btn = $(this);
+        const $panel = $btn.next('.guc-panel');
+        $btn.attr('aria-expanded', wantOpen ? 'true' : 'false');
+        $btn.find('.guc-caret').text(wantOpen ? '▴' : '▾');
+        if (wantOpen) $panel.show(); else $panel.hide();
       });
-      enhanceActionButtons($('#guc-cases-table'));
     }
 
-    function enhanceActionButtons($scope){
-      const S = $scope || $(document);
-      S.find('.guc-view').each(function(){ if(!$(this).text().trim()) $(this).html('👁 Ver'); });
-      S.find('.guc-edit').each(function(){ if(!$(this).text().trim()) $(this).html('✎ Editar'); });
-      S.find('.guc-del').each(function(){ if(!$(this).text().trim()) $(this).html('🗑 Eliminar'); });
-      S.find('.guc-upload').each(function(){ if(!$(this).text().trim()) $(this).html('⤴ Subir PDF'); });
-      S.find('.guc-pdf').each(function(){ if(!$(this).text().trim()) $(this).html('📄 PDF'); });
+    function setCaseHasActions(caseId, has){
+      const cid = String(caseId);
+      const $btn = $('.guc-start[data-id="'+cid+'"]').first();
+      if ($btn.length) {
+        $btn.text(has ? 'Agregar acción' : 'Iniciar caso');
+        $btn.closest('tr').attr('data-has-actions', has ? '1' : '0');
+      }
+    }
+
+    function updateCaseHasActions($sub){
+      if(!$sub || !$sub.length) return;
+      const caseId = $sub.attr('data-parent');
+      if(!caseId) return;
+      const has = $sub.find('tbody tr[data-row-id]').length > 0;
+      setCaseHasActions(caseId, has);
+    }
+
+    function resolveSectionKey($btn){
+      let section = $btn.data('section');
+      if(!section){
+        const $wrap = $btn.closest('.guc-subtable-wrap');
+        const secKey = $wrap.data('section');
+        if (secKey === 'secretaria') section = $wrap.attr('data-bucket') || 'sec_general';
+        else section = (secKey === 'pre') ? 'pre' : 'arb';
+      }
+      return section;
+    }
+
+    function openCaseRow($row, caseId, state){
+      if(!$row || !$row.length) return null;
+      const cid = String(caseId);
+      const $sub = ensureSubrow($row, cid);
+      if(!$sub || !$sub.length) return null;
+
+      const secBucket = state?.secretariaBucket?.[cid];
+      if (secBucket) {
+        const $wrap = $sub.find('.guc-subtable-wrap[data-section="secretaria"]');
+        $wrap.attr('data-bucket', secBucket);
+        $sub.find('[data-secretaria-title]').text(secBucket === 'sec_arbitral' ? 'Secretaría Arbitral' : 'Secretaría General');
+      }
+
+      const $preWrap = $sub.find('.guc-subtable-wrap[data-section="pre"]');
+      const $secWrap = $sub.find('.guc-subtable-wrap[data-section="secretaria"]');
+      const $arbWrap = $sub.find('.guc-subtable-wrap[data-section="arb"]');
+
+      renderSection($preWrap);
+      renderSection($secWrap);
+      renderSection($arbWrap);
+
+      applyPanelState($sub, state?.panels?.[cid]);
+      return $sub;
+    }
+
+    function restoreState(state){
+      const stored = state || readStoredState() || { openCases:[], panels:{}, secretariaBucket:{} };
+      const applied = new Set();
+
+      (stored.openCases || []).forEach(function(caseId){
+        const cid = String(caseId);
+        const $row = $tbody.find('tr[data-id="'+cid+'"]').first();
+        if(!$row.length) return;
+        openCaseRow($row, cid, stored);
+        applied.add(cid);
+      });
+
+      $tbody.find('tr[data-id][data-has-actions="1"]').each(function(){
+        const cid = String($(this).data('id'));
+        if(applied.has(cid)) return;
+        openCaseRow($(this), cid, stored);
+        applied.add(cid);
+      });
+
+      rememberState(captureState());
     }
 
 
@@ -181,12 +267,14 @@
      *  Datos (AJAX)
      * ========================= */
     function loadTable(){
-      const _state = captureState();
+      const runtimeState = captureState();
+      if (runtimeState.openCases && runtimeState.openCases.length) {
+        rememberState(runtimeState);
+      }
       $.post(GUC_CASOS.ajax, { action:'guc_list_cases', nonce:GUC_CASOS.nonce }, function(res){
         if (res && res.success) {
           $tbody.html(res.data.html);
-          enhanceActionButtons($tbody);
-          restoreState(_state);
+          restoreState(runtimeState.openCases && runtimeState.openCases.length ? runtimeState : null);
         } else {
           $tbody.html('<tr><td colspan="6" class="guc-empty">Error al cargar.</td></tr>');
         }
@@ -195,14 +283,25 @@
       });
     }
 
-    function loadUsers(selectedId){
-      return $.post(GUC_CASOS.ajax, { action:'guc_list_users', nonce:GUC_CASOS.nonce }, function(res){
+    function loadUsers(selectedId, includeId){
+      const payload = { action:'guc_list_users', nonce:GUC_CASOS.nonce };
+      if (includeId) payload.include_id = includeId;
+      return $.post(GUC_CASOS.ajax, payload, function(res){
         if (res && res.success) {
           $user.empty().append('<option value="">— Selecciona un usuario —</option>');
           res.data.forEach(function(u){
             $user.append('<option value="'+u.id+'" data-entity="'+(u.entity||'')+'" data-expediente="'+(u.expediente||'')+'">'+(u.username || ('ID '+u.id))+'</option>');
           });
-          if (selectedId) $user.val(String(selectedId));
+          if (selectedId) {
+            const sid = String(selectedId);
+            if (!$user.find('option[value="'+sid+'"]').length && res.data){
+              const current = res.data.find(function(u){ return String(u.id) === sid; });
+              if (current) {
+                $user.append('<option value="'+current.id+'" data-entity="'+(current.entity||'')+'" data-expediente="'+(current.expediente||'')+'">'+(current.username || ('ID '+current.id))+'</option>');
+              }
+            }
+            $user.val(sid);
+          }
         } else {
           alert(res?.data?.message || 'No se pudieron cargar usuarios');
         }
@@ -216,7 +315,6 @@
 
     $open.on('click', async function(){
       resetForm(); setMode('create'); await loadUsers('');
-      $form.find('[name=entidad],[name=expediente]').prop('disabled', true).addClass('guc-readonly');
       openModal();
     });
     $close.on('click', closeModal);
@@ -271,7 +369,7 @@
       $.post(GUC_CASOS.ajax, { action:'guc_get_case', nonce:GUC_CASOS.nonce, id }, async function(res){
         if (!(res && res.success)) { alert('No se pudo cargar el caso'); return; }
         const d = res.data || {};
-        resetForm(); await loadUsers(d.user_id); fillForm(d); $form.find('[name=entidad],[name=expediente]').prop('disabled', true).addClass('guc-readonly');
+        resetForm(); await loadUsers(d.user_id, d.user_id); fillForm(d);
         if ($(this).hasClass('guc-view')) setMode('view'); else setMode('edit');
         openModal(); setDirty(false);
       }.bind(this), 'json').fail(function(){ alert('Error de conexión al cargar'); });
@@ -286,7 +384,7 @@
     $tbody.on('click', '.guc-start', function(){
       $lastStartRow = $(this).closest('tr');
       const id = $(this).data('id');
-      if ($startForm[0]) $startForm[0].reset();
+      resetStartModal();
       $startForm.find('[name=case_id]').val(id || '');
 
       // autollenar fecha actual
@@ -359,7 +457,11 @@
         const bucket = $wrap.attr('data-bucket'); // sec_arbitral | sec_general
         const doList = function(bucketKey){
           $.post(GUC_CASOS.ajax, { action:'guc_list_section', nonce:GUC_CASOS.nonce, case_id:caseId, section: bucketKey }, function(res){
-            if (res && res.success) { $wrap.html(res.data.html); enhanceActionButtons($wrap); }
+            if (res && res.success) {
+              $wrap.html(res.data.html);
+              updateCaseHasActions($wrap.closest('tr.guc-subrow'));
+              rememberState(captureState());
+            }
             else $wrap.html('<div class="guc-empty">No se pudo cargar Secretaría.</div>');
           }, 'json').fail(function(){ $wrap.html('<div class="guc-empty">Error de conexión.</div>'); });
         };
@@ -378,7 +480,11 @@
       } else {
         const key = section === 'pre' ? 'pre' : 'arb';
         $.post(GUC_CASOS.ajax, { action:'guc_list_section', nonce:GUC_CASOS.nonce, case_id:caseId, section:key }, function(res){
-          if (res && res.success) { $wrap.html(res.data.html); enhanceActionButtons($wrap); }
+          if (res && res.success) {
+            $wrap.html(res.data.html);
+            updateCaseHasActions($wrap.closest('tr.guc-subrow'));
+            rememberState(captureState());
+          }
           else $wrap.html('<div class="guc-empty">No se pudo cargar.</div>');
         }, 'json').fail(function(){ $wrap.html('<div class="guc-empty">Error de conexión.</div>'); });
       }
@@ -392,6 +498,7 @@
       $btn.attr('aria-expanded', !expanded);
       $btn.find('.guc-caret').text(expanded ? '▾' : '▴');
       if (expanded) { $panel.slideUp(160); } else { $panel.slideDown(160); }
+      rememberState(captureState());
     });
 
     /* ==========================================================
@@ -401,7 +508,7 @@
       const sectionKey = $(this).data('section'); // pre | sec_arbitral | sec_general | arb
       const caseId = $(this).data('case-id');
 
-      if ($startForm[0]) $startForm[0].reset();
+      resetStartModal();
       $startForm.find('[name=case_id]').val(caseId);
       $startModal.attr('data-target-section', sectionKey); // <- destino explícito
 
@@ -424,18 +531,12 @@
       const rowId = $row.data('row-id');
       if(!rowId) return;
       // infer section from container if not provided in data-section
-      let section = $btn.data('section');
-      if(!section){
-        const $wrap = $btn.closest('.guc-subtable-wrap');
-        const secKey = $wrap.data('section'); // pre | secretaria | arb
-        if (secKey === 'secretaria') section = $wrap.attr('data-bucket') || 'sec_general';
-        else section = (secKey === 'pre') ? 'pre' : 'arb';
-      }
+      const section = resolveSectionKey($btn);
 
       $.post(GUC_CASOS.ajax, { action:'guc_get_section_row', nonce:GUC_CASOS.nonce, section, row_id: rowId }, function(res){
         if(!(res && res.success)){ alert(res?.data?.message || 'No se pudo obtener la fila'); return; }
         const d = res.data || {};
-        if ($startForm[0]) $startForm[0].reset();
+        resetStartModal();
         $startModal.attr('data-target-section', section).attr('data-edit-row', String(rowId));
         $startForm.find('[name=case_id]').val(d.case_id || '');
         $startForm.find('[name=situacion]').val(d.situacion || '');
@@ -445,8 +546,29 @@
           const isoLocal = d.fecha.replace(' ', 'T').slice(0,16);
           $startForm.find('[name=fecha]').val(isoLocal);
         }
-        openStart();
+        openStart('edit');
       }, 'json').fail(function(){ alert('Error de conexión'); });
+    });
+
+    $(document).on('click', '.guc-row-del', function(){
+      const $btn = $(this);
+      const section = resolveSectionKey($btn);
+      const rowId = $btn.closest('tr').data('row-id');
+      if (!rowId || !section) return;
+      const $wrap = $btn.closest('.guc-subtable-wrap');
+      if (!confirm('¿Eliminar esta acción?')) return;
+      $btn.prop('disabled', true);
+      $.post(GUC_CASOS.ajax, { action:'guc_delete_section_row', nonce:GUC_CASOS.nonce, section, row_id: rowId }, function(res){
+        if (res && res.success){
+          renderSection($wrap);
+        } else {
+          alert(res?.data?.message || 'No se pudo eliminar la acción');
+          $btn.prop('disabled', false);
+        }
+      }, 'json').fail(function(){
+        alert('Error de conexión al eliminar');
+        $btn.prop('disabled', false);
+      });
     });
 
 
@@ -493,7 +615,6 @@
             if (!(res && res.success)) { alert(res?.data?.message || (editingRow?'No se pudo actualizar la acción':'No se pudo registrar la acción')); return; }
 
             closeStart(); // cerrar modal y limpiar destino
-            $startModal.removeAttr('data-target-section').removeAttr('data-edit-row');
 
             // refrescar SOLO la subtabla correspondiente
             const $sub = $('tr.guc-subrow[data-parent="'+data.case_id+'"]');
@@ -559,9 +680,12 @@
      * ========================================================== */
     $(document).on('click', '.guc-upload', function(){
       const $btn = $(this);
-      const section = $btn.data('section'); // pre | sec_arbitral | sec_general | arb
+      const section = resolveSectionKey($btn); // pre | sec_arbitral | sec_general | arb
       const rowId   = $btn.closest('tr').data('row-id');
-      if (!rowId) return;
+      if (!rowId || !section) return;
+
+      const $wrap = $btn.closest('.guc-subtable-wrap');
+      const originalHtml = $btn.html();
 
       const $input = $('<input type="file" accept="application/pdf" style="display:none">');
       $('body').append($input);
@@ -574,106 +698,46 @@
         fd.append('row_id', rowId);
         fd.append('file', this.files[0]);
 
-        $btn.prop('disabled', true).text('Subiendo...');
+        $btn.prop('disabled', true).attr('data-loading','1').text('Subiendo...');
         $.ajax({
           url: GUC_CASOS.ajax,
           type: 'POST',
           data: fd, contentType:false, processData:false, dataType:'json'
         }).done(function(res){
           if (res && res.success) {
-            $btn.replaceWith('<a class="guc-btn guc-btn-secondary" target="_blank" rel="noopener" href="'+res.data.pdf_url+'">PDF subido</a>');
+            renderSection($wrap);
           } else {
             alert(res?.data?.message || 'No se pudo subir el PDF');
-            $btn.prop('disabled', false).text('Subir PDF');
+            $btn.prop('disabled', false).html(originalHtml);
           }
         }).fail(function(){
           alert('Error de conexión al subir PDF');
-          $btn.prop('disabled', false).text('Subir PDF');
+          $btn.prop('disabled', false).html(originalHtml);
         }).always(function(){ $input.remove(); });
       }).trigger('click');
     });
 
 
-    /* ==========================================================
-     *  PDF: menú Ver / Reemplazar / Eliminar
-     * ========================================================== */
-    function buildPdfMenu($anchor, opts){
-      $('.guc-pdf-menu').remove(); // close others
-      const menu = $('<div class="guc-pdf-menu" />').css({
-        position:'absolute', zIndex: 100002, background:'#fff', border:'1px solid #eadfce', borderRadius:'8px',
-        boxShadow:'0 8px 20px rgba(0,0,0,.12)', overflow:'hidden'
-      });
-      const mkBtn = (label, cls)=> $('<button type="button" />').addClass(cls).css({display:'block',padding:'8px 12px',border:0,background:'#fff',width:'100%',textAlign:'left',cursor:'pointer'}).text(label);
-      const $v = mkBtn('Ver', 'guc-pdf-view');
-      const $r = mkBtn('Reemplazar', 'guc-pdf-replace');
-      const $d = mkBtn('Eliminar', 'guc-pdf-delete');
-      menu.append($v,$r,$d);
-      $('body').append(menu);
-      const off = $anchor.offset(); const h = $anchor.outerHeight();
-      menu.css({left: off.left, top: off.top + h + 6});
-      setTimeout(function(){
-        $(document).one('mousedown.gucPdfMenu', function(e){
-          if ($(e.target).closest('.guc-pdf-menu, .guc-pdf').length) return;
-          $('.guc-pdf-menu').remove();
-        });
-      }, 0);
-      return menu;
-    }
-
-    $(document).on('click', '.guc-pdf', function(){
+    $(document).on('click', '.guc-clear-pdf', function(){
       const $btn = $(this);
-      const $row = $btn.closest('tr');
-      const rowId = $row.data('row-id'); if(!rowId) return;
-      let section = $btn.data('section');
-      if(!section){
-        const $wrap = $btn.closest('.guc-subtable-wrap');
-        const secKey = $wrap.data('section');
-        if (secKey === 'secretaria') section = $wrap.attr('data-bucket') || 'sec_general';
-        else section = (secKey === 'pre') ? 'pre' : 'arb';
-      }
-      const menu = buildPdfMenu($btn);
-
-      menu.off('click', '.guc-pdf-view').on('click', '.guc-pdf-view', function(){
-        // attempt to get current URL
-        $.post(GUC_CASOS.ajax, { action:'guc_get_section_row', nonce:GUC_CASOS.nonce, section, row_id: rowId }, function(res){
-          if (res && res.success && res.data && res.data.pdf_url){ window.open(res.data.pdf_url, '_blank'); }
-          else alert('No hay PDF para esta fila.');
-          $('.guc-pdf-menu').remove();
-        }, 'json').fail(function(){ alert('Error de conexión'); $('.guc-pdf-menu').remove(); });
-      });
-
-      menu.off('click', '.guc-pdf-replace').on('click', '.guc-pdf-replace', function(){
-        const $input = $('<input type="file" accept="application/pdf" style="display:none">').appendTo('body');
-        $input.on('change', function(){
-          if (!this.files || !this.files[0]) { $input.remove(); $('.guc-pdf-menu').remove(); return; }
-          const fd = new FormData();
-          fd.append('action','guc_upload_pdf'); fd.append('nonce', GUC_CASOS.nonce);
-          fd.append('section', section); fd.append('row_id', rowId); fd.append('file', this.files[0]);
-          $.ajax({ url: GUC_CASOS.ajax, type:'POST', data: fd, contentType:false, processData:false, dataType:'json' })
-          .done(function(res){
-            if(res && res.success){
-              // refresh only this wrap
-              const $wrap = $btn.closest('.guc-subtable-wrap');
-              renderSection($wrap);
-            } else alert(res?.data?.message || 'No se pudo subir el PDF');
-          }).fail(function(){ alert('Error de conexión'); })
-          .always(function(){ $input.remove(); $('.guc-pdf-menu').remove(); });
-        }).trigger('click');
-      });
-
-      menu.off('click', '.guc-pdf-delete').on('click', '.guc-pdf-delete', function(){
-        if(!confirm('¿Eliminar el PDF de esta fila?')) { $('.guc-pdf-menu').remove(); return; }
-        $.post(GUC_CASOS.ajax, { action:'guc_clear_pdf', nonce:GUC_CASOS.nonce, section, row_id: rowId }, function(res){
-          if (res && res.success){
-            const $wrap = $btn.closest('.guc-subtable-wrap');
-            renderSection($wrap);
-          } else alert(res?.data?.message || 'No se pudo eliminar el PDF');
-          $('.guc-pdf-menu').remove();
-        }, 'json').fail(function(){ alert('Error de conexión'); $('.guc-pdf-menu').remove(); });
+      const rowId = $btn.closest('tr').data('row-id');
+      const section = resolveSectionKey($btn);
+      if (!rowId || !section) return;
+      const $wrap = $btn.closest('.guc-subtable-wrap');
+      if (!confirm('¿Eliminar el PDF de esta fila?')) return;
+      $btn.prop('disabled', true);
+      $.post(GUC_CASOS.ajax, { action:'guc_clear_pdf', nonce:GUC_CASOS.nonce, section, row_id: rowId }, function(res){
+        if (res && res.success){
+          renderSection($wrap);
+        } else {
+          alert(res?.data?.message || 'No se pudo eliminar el PDF');
+          $btn.prop('disabled', false);
+        }
+      }, 'json').fail(function(){
+        alert('Error de conexión al eliminar PDF');
+        $btn.prop('disabled', false);
       });
     });
-
-
     /* ==========================================================
      *  Carga inicial de tabla de casos
      * ========================================================== */

--- a/guc-casos.php
+++ b/guc-casos.php
@@ -192,6 +192,19 @@ final class GUC_Casos_Compact {
     return null;
   }
 
+  private function case_has_actions($case_id){
+    global $wpdb;
+    $case_id = intval($case_id);
+    if(!$case_id) return false;
+    $tables = [$this->t_events, $this->t_pre, $this->t_arb, $this->t_sec_arbitral, $this->t_sec_general];
+    foreach($tables as $t){
+      if(!$t) continue;
+      $count = intval($wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM `$t` WHERE case_id=%d", $case_id)));
+      if($count > 0) return true;
+    }
+    return false;
+  }
+
   // ====== AJAX ======
   public function guc_list_cases(){
     $this->check_nonce(); global $wpdb;
@@ -203,10 +216,10 @@ final class GUC_Casos_Compact {
       $ent = $this->html_esc($r->entidad);
       $nom = $this->html_esc($r->nomenclature);
       $usr = $this->html_esc($r->username);
-      $has_events = intval($wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$this->t_events} WHERE case_id=%d",$r->id))) > 0;
-      $hist_btn = $has_events ? 'Agregar acción' : 'Iniciar caso';
+      $has_actions = $this->case_has_actions($r->id);
+      $hist_btn = $has_actions ? 'Agregar acción' : 'Iniciar caso';
 
-      echo '<tr data-id="'.intval($r->id).'">';
+      echo '<tr data-id="'.intval($r->id).'" data-has-actions="'.($has_actions ? '1' : '0').'">';
       echo "<td>{$exp}</td><td>{$ent}</td><td>{$nom}</td><td>{$usr}</td>";
       echo '<td><button class="guc-btn guc-btn-secondary guc-start" data-id="'.intval($r->id).'">'.$hist_btn.'</button></td>';
       echo '<td>';
@@ -223,7 +236,16 @@ final class GUC_Casos_Compact {
 
   public function guc_list_users(){
     $this->check_nonce(); global $wpdb;
-    $rows = $wpdb->get_results("SELECT u.* FROM {$this->t_users} u WHERE NOT EXISTS (SELECT 1 FROM {$this->t_cases} c WHERE c.user_id=u.id) ORDER BY u.id DESC");
+    $include_id = intval($_POST['include_id'] ?? 0);
+    if ($include_id) {
+      $sql = $wpdb->prepare(
+        "SELECT u.* FROM {$this->t_users} u WHERE NOT EXISTS (SELECT 1 FROM {$this->t_cases} c WHERE c.user_id=u.id) OR u.id=%d ORDER BY u.id DESC",
+        $include_id
+      );
+    } else {
+      $sql = "SELECT u.* FROM {$this->t_users} u WHERE NOT EXISTS (SELECT 1 FROM {$this->t_cases} c WHERE c.user_id=u.id) ORDER BY u.id DESC";
+    }
+    $rows = $wpdb->get_results($sql);
     $out = [];
     foreach($rows as $r){
       $out[] = ['id'=>intval($r->id),'username'=>$r->username,'entity'=>$r->entity,'expediente'=>$r->expediente];


### PR DESCRIPTION
## Summary
- clean up the start/action modal handling so it tracks mode (create vs edit), resets correctly, and locks fields that must stay read-only when editing cases
- persist the accordion/subtable state between refreshes via localStorage and ensure sections re-render with the right Secretariat bucket while keeping action buttons responsive
- unify row-level action controls so PDF upload/replacement/removal and row deletion refresh the correct section and expose the assigned user while editing cases

## Testing
- php -l guc-casos.php

------
https://chatgpt.com/codex/tasks/task_e_68e54d3db4d8832a94d3b988ad204c43