### PR TITLE
Reset search behavior and isolate Gestion Casos modals

### DIFF
--- a/assets/guc-casos.css
+++ b/assets/guc-casos.css
@@ -1,7 +1,39 @@
 /* ===== base ===== */
 #guc-casos.guc-wrap{font-family:'Inter',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#2b2b2b;}
-#guc-casos .guc-header{display:flex;align-items:center;justify-content:space-between;margin:8px 0 16px;}
-#guc-casos .guc-title{font-weight:800;font-size:22px;margin:0;}
+#guc-casos .guc-header{display:flex;align-items:center;justify-content:space-between;margin:8px 0 16px;gap:12px;flex-wrap:wrap;}
+#guc-casos .guc-title{font-weight:800;font-size:22px;margin:0;margin-right:auto;}
+#guc-casos .guc-header-controls{display:flex;align-items:center;gap:10px;flex-wrap:wrap;justify-content:flex-end;}
+#guc-casos .guc-header-controls>*{flex-shrink:0;}
+#guc-casos .guc-search{display:flex;align-items:center;gap:6px;border:1px solid #d9c8b3;border-radius:999px;background:#fff;box-shadow:0 2px 6px rgba(0,0,0,.08);padding:4px 6px;min-width:220px;}
+#guc-casos .guc-search input{border:0;background:transparent;padding:6px 8px 6px 10px;font-size:14px;color:#3f3a34;min-width:0;flex:1 1 auto;}
+#guc-casos .guc-search input:focus{outline:0;}
+#guc-casos .guc-search:focus-within{box-shadow:0 0 0 2px rgba(191,162,123,.28);}
+#guc-casos .guc-search-btn{border:0;background:#bfa27b;color:#fff;border-radius:999px;width:40px;height:32px;display:flex;align-items:center;justify-content:center;cursor:pointer;transition:background .15s ease,transform .12s ease;}
+#guc-casos .guc-search-btn:hover{background:#ae926a;}
+#guc-casos .guc-search-btn:active{transform:scale(.94);}
+#guc-casos .guc-filter{position:relative;}
+#guc-casos .guc-filter[data-filter-active="1"] .guc-filter-toggle{background:#bfa27b;color:#fff;border-color:#b08f61;}
+#guc-casos .guc-filter[data-filter-active="1"] .guc-filter-toggle .guc-ico-mini::before{background-color:#fff;}
+#guc-casos .guc-filter-toggle{display:flex;align-items:center;gap:6px;border:1px solid #d9c8b3;border-radius:999px;background:#ede6dc;color:#4a3a2a;font-weight:600;padding:6px 12px;cursor:pointer;transition:background .15s ease,transform .12s ease;}
+#guc-casos .guc-filter-toggle:hover{background:#e1d7c8;}
+#guc-casos .guc-filter-toggle:active{transform:scale(.97);}
+#guc-casos .guc-filter-text{font-size:14px;}
+#guc-casos .guc-filter-menu{position:absolute;top:calc(100% + 8px);right:0;min-width:170px;background:#fff;border:1px solid #eadfce;border-radius:14px;box-shadow:0 14px 28px rgba(0,0,0,.16);padding:8px;display:flex;flex-direction:column;z-index:10;opacity:0;transform:translateY(-6px);pointer-events:none;transition:opacity .18s ease,transform .18s ease;}
+#guc-casos .guc-filter-menu[hidden]{display:none!important;}
+#guc-casos .guc-filter.is-open .guc-filter-menu{opacity:1;transform:translateY(0);pointer-events:auto;}
+#guc-casos .guc-filter-menu button{border:0;background:transparent;text-align:left;padding:8px 12px;border-radius:10px;font-weight:600;color:#4a3a2a;cursor:pointer;transition:background .15s ease,color .15s ease;display:flex;align-items:center;gap:10px;}
+#guc-casos .guc-filter-menu button:hover{background:#f6efe5;}
+#guc-casos .guc-filter-menu button.is-active{background:#f0e7db;color:#3f3328;}
+#guc-casos .guc-filter-check{width:18px;height:18px;border-radius:999px;border:2px solid #d3c6b5;display:inline-flex;align-items:center;justify-content:center;position:relative;transition:background .18s ease,border-color .18s ease,color .18s ease;}
+#guc-casos .guc-filter-menu button.is-active .guc-filter-check{background:#bfa27b;border-color:#bfa27b;color:#fff;}
+#guc-casos .guc-filter-check::before{content:"";width:10px;height:10px;display:block;background-color:currentColor;mask-repeat:no-repeat;mask-position:center;mask-size:contain;mask-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='currentColor' d='M8.2 13.4l-3.4-3.4-1.4 1.4 4.8 4.8 8.8-8.8-1.4-1.4z'/></svg>");opacity:0;transition:opacity .18s ease;}
+#guc-casos .guc-filter-menu button.is-active .guc-filter-check::before{opacity:1;}
+#guc-casos .guc-filter-label{flex:1 1 auto;}
+#guc-casos .guc-visually-hidden{position:absolute!important;width:1px!important;height:1px!important;padding:0!important;margin:-1px!important;overflow:hidden!important;clip:rect(0,0,0,0)!important;white-space:nowrap!important;border:0!important;}
+#guc-casos .guc-ico-mini{display:inline-flex;width:18px;height:18px;align-items:center;justify-content:center;}
+#guc-casos .guc-ico-mini::before{content:"";display:block;width:18px;height:18px;background-color:currentColor;mask-repeat:no-repeat;mask-position:center;mask-size:contain;}
+#guc-casos .guc-ico-mini.guc-ico-search::before{mask-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='currentColor' d='M15.5 14h-.79l-.28-.27A6.5 6.5 0 1 0 14 15.5l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0A4.5 4.5 0 1 1 10 5a4.5 4.5 0 0 1-.5 9z'/></svg>");}
+#guc-casos .guc-ico-mini.guc-ico-filter::before{mask-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='currentColor' d='M3 5h18v2l-7 7v4l-4 3v-7L3 7V5z'/></svg>");}
 
 /* ===== botones ===== */
 #guc-casos .guc-btn{border:0;border-radius:14px;padding:10px 16px;cursor:pointer;transition:.15s;box-shadow:0 2px 6px rgba(0,0,0,.08);font-weight:600;}
@@ -14,45 +46,87 @@
 #guc-casos .guc-table{width:100%;border-collapse:separate;border-spacing:0;}
 #guc-casos .guc-table thead th{background:#f6f1ea;color:#2b241d;font-weight:700;padding:12px;border-bottom:1px solid #eadfce;text-align:left;}
 #guc-casos .guc-table td{padding:12px;border-bottom:1px solid #f1ebe2;color:#2b2b2b;}
+#guc-casos .guc-table tbody tr[data-search-match="1"] td{background:#fff6e8;}
 #guc-casos .guc-empty{color:#8a7a66;text-align:center;padding:16px;}
 
 /* ===== acciones ===== */
-#guc-casos .guc-actions .guc-act{border:0;border-radius:10px;padding:8px;cursor:pointer;margin-right:6px;}
-#guc-casos .guc-actions .guc-view{background:#9e9e9e;color:#fff;}
-#guc-casos .guc-actions .guc-edit{background:#ffa000;color:#2b241d;}
-#guc-casos .guc-actions .guc-del{background:#e53935;color:#fff;}
+#guc-casos .guc-actions{display:flex;align-items:center;gap:8px;}
+#guc-casos .guc-actions .guc-act{border:0;padding:0;background:transparent;cursor:pointer;}
+#guc-casos .guc-actions .guc-act .guc-ico{margin-right:0;}
 #guc-casos .guc-pill{background:#4b3a31;color:#fff;border:0;border-radius:10px;padding:6px 10px;font-weight:700;}
 
 /* ===== modales (igual a lo tuyo) ===== */
-#guc-modal, #guc-modal-start{
+#guc-casos-modal, #guc-casos-modal-start, #guc-casos-modal-status{
   position:fixed; inset:0; display:none; z-index:100000;
   background:rgba(0,0,0,.28); -webkit-backdrop-filter:blur(1px); backdrop-filter:blur(1px);
 }
-#guc-modal.show, #guc-modal-start.show{display:flex;align-items:center;justify-content:center;}
-#guc-modal .guc-modal-dialog, #guc-modal-start .guc-modal-dialog{
+#guc-casos-modal.show, #guc-casos-modal-start.show, #guc-casos-modal-status.show{display:flex;align-items:center;justify-content:center;}
+#guc-casos-modal .guc-modal-dialog, #guc-casos-modal-start .guc-modal-dialog, #guc-casos-modal-status .guc-modal-dialog{
   position:fixed; left:50%; top:50%; transform:translate(-50%,-50%);
   width:min(760px,calc(100% - 48px)); max-height:85vh; overflow:auto;
   background:#fff; border-radius:20px; border:1px solid #eadfce; box-shadow:0 20px 40px rgba(0,0,0,.20); z-index:100001;
 }
-.guc-modal-header{display:flex;justify-content:space-between;align-items:center;padding:16px 20px;border-bottom:1px solid #f0e7db;background:#3e2e25;color:#fff;}
-.guc-modal-header h3{margin:0;color:#fff;}
-.guc-modal-close{background:transparent;border:0;font-size:20px;cursor:pointer;color:#ffdfdf;}
-.guc-modal-body{padding:18px 20px;background:#fff;}
-.guc-modal-footer{padding:14px 20px;border-top:1px solid #f0e7db;display:flex;justify-content:flex-end;gap:10px;background:#fff;}
+#guc-casos-modal .guc-modal-header,
+#guc-casos-modal-start .guc-modal-header,
+#guc-casos-modal-status .guc-modal-header{display:flex;justify-content:space-between;align-items:center;padding:16px 20px;border-bottom:1px solid #f0e7db;background:#3e2e25;color:#fff;}
+#guc-casos-modal .guc-modal-header h3,
+#guc-casos-modal-start .guc-modal-header h3,
+#guc-casos-modal-status .guc-modal-header h3{margin:0;color:#fff;}
+#guc-casos-modal .guc-modal-close,
+#guc-casos-modal-start .guc-modal-close,
+#guc-casos-modal-status .guc-modal-close{background:transparent;border:0;font-size:20px;cursor:pointer;color:#ffdfdf;}
+#guc-casos-modal .guc-modal-body,
+#guc-casos-modal-start .guc-modal-body,
+#guc-casos-modal-status .guc-modal-body{padding:18px 20px;background:#fff;}
+#guc-casos-modal .guc-modal-footer,
+#guc-casos-modal-start .guc-modal-footer,
+#guc-casos-modal-status .guc-modal-footer{padding:14px 20px;border-top:1px solid #f0e7db;display:flex;justify-content:flex-end;gap:10px;background:#fff;}
 
 /* ===== formulario ===== */
-.guc-field{margin-bottom:14px;}
-.guc-field label{display:block;margin-bottom:6px;color:#2b241d;font-weight:700;}
-.guc-field input[type=text], .guc-field textarea, .guc-field select{width:100%;padding:10px 12px;border:1px solid #e1d7c8;border-radius:12px;outline:0;background:#fff;}
-.guc-field textarea{resize:vertical;min-height:110px;}
-.guc-help{display:block;margin-top:6px;color:#8a7a66;}
-.guc-row{display:grid;grid-template-columns:1fr 1fr;gap:12px;}
-.guc-col{min-width:0;}
-@media (max-width:640px){.guc-row{grid-template-columns:1fr;}}
+#guc-casos .guc-field,
+#guc-casos-modal .guc-field,
+#guc-casos-modal-start .guc-field,
+#guc-casos-modal-status .guc-field{margin-bottom:14px;}
+#guc-casos .guc-field label,
+#guc-casos-modal .guc-field label,
+#guc-casos-modal-start .guc-field label,
+#guc-casos-modal-status .guc-field label{display:block;margin-bottom:6px;color:#2b241d;font-weight:700;}
+#guc-casos .guc-field input[type=text],
+#guc-casos .guc-field textarea,
+#guc-casos .guc-field select,
+#guc-casos-modal .guc-field input[type=text],
+#guc-casos-modal .guc-field textarea,
+#guc-casos-modal .guc-field select,
+#guc-casos-modal-start .guc-field input[type=text],
+#guc-casos-modal-start .guc-field textarea,
+#guc-casos-modal-start .guc-field select,
+#guc-casos-modal-status .guc-field input[type=text],
+#guc-casos-modal-status .guc-field textarea,
+#guc-casos-modal-status .guc-field select{width:100%;padding:10px 12px;border:1px solid #e1d7c8;border-radius:12px;outline:0;background:#fff;}
+#guc-casos .guc-field textarea,
+#guc-casos-modal .guc-field textarea,
+#guc-casos-modal-start .guc-field textarea,
+#guc-casos-modal-status .guc-field textarea{resize:vertical;min-height:110px;}
+#guc-casos .guc-help,
+#guc-casos-modal .guc-help,
+#guc-casos-modal-start .guc-help,
+#guc-casos-modal-status .guc-help{display:block;margin-top:6px;color:#8a7a66;}
+#guc-casos .guc-row,
+#guc-casos-modal .guc-row,
+#guc-casos-modal-start .guc-row,
+#guc-casos-modal-status .guc-row{display:grid;grid-template-columns:1fr 1fr;gap:12px;}
+#guc-casos .guc-col,
+#guc-casos-modal .guc-col,
+#guc-casos-modal-start .guc-col,
+#guc-casos-modal-status .guc-col{min-width:0;}
+@media (max-width:640px){#guc-casos .guc-row,#guc-casos-modal .guc-row,#guc-casos-modal-start .guc-row,#guc-casos-modal-status .guc-row{grid-template-columns:1fr;}}
 
 /* sólo lectura */
-.guc-readonly{background:#fbf8f3;color:#6b5e50;}
-body.guc-no-scroll{overflow:hidden;}
+#guc-casos .guc-readonly,
+#guc-casos-modal .guc-readonly,
+#guc-casos-modal-start .guc-readonly,
+#guc-casos-modal-status .guc-readonly{background:#fbf8f3;color:#6b5e50;}
+body.guc-casos-no-scroll{overflow:hidden;}
 
 /* ===== subfilas y subtables ===== */
 #guc-casos .guc-subrow .guc-subrow-cell{ padding:.75rem 1rem; background:#fff; border-top:1px solid #e5e2dd; }
@@ -87,6 +161,72 @@ body.guc-no-scroll{overflow:hidden;}
 #guc-casos .guc-subtable.guc-subtable-compact td{padding:8px 10px;font-size:13px}
 #guc-casos .guc-subtable-footer{margin-top:6px}
 /* icon action buttons */
-.guc-ico{display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;border:1px solid #eadfce;border-radius:8px;background:#fff;cursor:pointer;margin-right:6px}
-.guc-ico:hover{background:#f6f1ea}
-.guc-ico:disabled{opacity:.6;cursor:not-allowed}
+#guc-casos .guc-hidden,
+#guc-casos-modal .guc-hidden,
+#guc-casos-modal-start .guc-hidden,
+#guc-casos-modal-status .guc-hidden{display:none!important}
+
+#guc-casos .guc-ico,
+#guc-casos-modal .guc-ico,
+#guc-casos-modal-start .guc-ico,
+#guc-casos-modal-status .guc-ico{display:inline-flex;align-items:center;justify-content:center;width:56px;height:56px;border:1px solid #d9c8b3;border-radius:16px;background:#fff;cursor:pointer;margin-right:8px;color:#6b5e50;transition:background .15s ease,transform .12s ease}
+#guc-casos .guc-ico::before,
+#guc-casos-modal .guc-ico::before,
+#guc-casos-modal-start .guc-ico::before,
+#guc-casos-modal-status .guc-ico::before{content:"";display:block;width:32px;height:32px;background-color:currentColor;mask-repeat:no-repeat;mask-position:center;mask-size:contain}
+#guc-casos .guc-ico:hover,
+#guc-casos-modal .guc-ico:hover,
+#guc-casos-modal-start .guc-ico:hover,
+#guc-casos-modal-status .guc-ico:hover{background:#f4ede4;transform:translateY(-1px)}
+#guc-casos .guc-ico:active,
+#guc-casos-modal .guc-ico:active,
+#guc-casos-modal-start .guc-ico:active,
+#guc-casos-modal-status .guc-ico:active{transform:scale(.95)}
+#guc-casos .guc-ico[data-loading="1"],
+#guc-casos-modal .guc-ico[data-loading="1"],
+#guc-casos-modal-start .guc-ico[data-loading="1"],
+#guc-casos-modal-status .guc-ico[data-loading="1"]{opacity:.6;cursor:progress}
+#guc-casos .guc-ico:disabled,
+#guc-casos-modal .guc-ico:disabled,
+#guc-casos-modal-start .guc-ico:disabled,
+#guc-casos-modal-status .guc-ico:disabled{opacity:.45;cursor:not-allowed}
+#guc-casos .guc-ico.has-pdf,#guc-casos .guc-ico[data-has-pdf="1"],
+#guc-casos-modal .guc-ico.has-pdf,#guc-casos-modal .guc-ico[data-has-pdf="1"],
+#guc-casos-modal-start .guc-ico.has-pdf,#guc-casos-modal-start .guc-ico[data-has-pdf="1"],
+#guc-casos-modal-status .guc-ico.has-pdf,#guc-casos-modal-status .guc-ico[data-has-pdf="1"]{background:#f8f1e8;border-color:#cdb997;color:#4a3a2a}
+#guc-casos .guc-ico.guc-ico-upload::before,
+#guc-casos-modal .guc-ico.guc-ico-upload::before,
+#guc-casos-modal-start .guc-ico.guc-ico-upload::before,
+#guc-casos-modal-status .guc-ico.guc-ico-upload::before{mask-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='currentColor' d='M12 3l4.5 4.5h-2.5V13h-4V7.5H7.5L12 3zm-7 14h14v2H5v-2z'/></svg>")}
+#guc-casos .guc-ico.guc-ico-edit::before,
+#guc-casos-modal .guc-ico.guc-ico-edit::before,
+#guc-casos-modal-start .guc-ico.guc-ico-edit::before,
+#guc-casos-modal-status .guc-ico.guc-ico-edit::before{mask-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='currentColor' d='M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zm2.92 1.83l10.9-10.9 1.79 1.79-10.9 10.9H5.92zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.13 1.13 3.75 3.75 1.13-1.13z'/></svg>")}
+#guc-casos .guc-ico.guc-ico-del::before,
+#guc-casos-modal .guc-ico.guc-ico-del::before,
+#guc-casos-modal-start .guc-ico.guc-ico-del::before,
+#guc-casos-modal-status .guc-ico.guc-ico-del::before{mask-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='currentColor' d='M6 7h12v12a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V7zm3-4h6l1 1h4v2H4V4h4l1-1zm1 6v10h2V9h-2zm4 0v10h2V9h-2z'/></svg>")}
+#guc-casos .guc-ico.guc-ico-view::before,
+#guc-casos-modal .guc-ico.guc-ico-view::before,
+#guc-casos-modal-start .guc-ico.guc-ico-view::before,
+#guc-casos-modal-status .guc-ico.guc-ico-view::before{mask-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='currentColor' d='M12 5c-5.05 0-9.27 3.11-11 7 1.73 3.89 5.95 7 11 7s9.27-3.11 11-7c-1.73-3.89-5.95-7-11-7zm0 12c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8a3 3 0 1 0 0 6 3 3 0 0 0 0-6z'/></svg>")}
+#guc-casos .guc-ico.guc-ico-gear::before,
+#guc-casos-modal .guc-ico.guc-ico-gear::before,
+#guc-casos-modal-start .guc-ico.guc-ico-gear::before,
+#guc-casos-modal-status .guc-ico.guc-ico-gear::before{mask-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='currentColor' d='M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58a.5.5 0 0 0 .12-.64l-1.92-3.32a.5.5 0 0 0-.6-.22l-2.39.96a7.02 7.02 0 0 0-1.63-.94l-.36-2.54A.5.5 0 0 0 14.39 2h-3.78a.5.5 0 0 0-.5.42l-.36 2.54c-.6.23-1.15.54-1.66.9l-2.39-.96a.5.5 0 0 0-.6.22L2.18 8.44a.5.5 0 0 0 .12.64l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58a.5.5 0 0 0-.12.64l1.92 3.32c.13.23.4.32.64.22l2.39-.96c.48.37 1.03.67 1.63.94l.36 2.54a.5.5 0 0 0 .5.42h3.78a.5.5 0 0 0 .5-.42l.36-2.54c.6-.23 1.15-.54 1.66-.9l2.39.96c.24.1.51.01.64-.22l1.92-3.32a.5.5 0 0 0-.12-.64l-2.03-1.58zM12 15.5a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7z'/></svg>")}
+
+#guc-action-pdf{margin-top:6px}
+#guc-action-pdf .guc-pdf-card{display:flex;align-items:center;justify-content:space-between;gap:14px;padding:12px 14px;border:1px solid #eadfce;border-radius:14px;background:#fbf6ef}
+#guc-action-pdf .guc-pdf-meta{display:flex;flex-direction:column;gap:6px;min-width:0}
+#guc-action-pdf .guc-pdf-name{font-weight:600;color:#3f3a34;word-break:break-all}
+#guc-action-pdf[data-has-pdf="0"] .guc-pdf-name{color:#a09484;font-weight:500}
+#guc-action-pdf .guc-pdf-link{font-size:13px;font-weight:600;color:#8a6d45;text-decoration:none}
+#guc-action-pdf .guc-pdf-link:hover{text-decoration:underline}
+#guc-action-pdf .guc-pdf-buttons{display:flex;gap:8px}
+#guc-action-pdf .guc-ico{margin-right:0}
+
+#guc-casos-modal-status .guc-modal-status-grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+@media(max-width:640px){#guc-casos-modal-status .guc-modal-status-grid{grid-template-columns:1fr}}
+
+@media(max-width:900px){#guc-casos .guc-header-controls{width:100%;justify-content:flex-start;}#guc-casos .guc-search{flex:1 1 220px;}#guc-casos .guc-filter-toggle{padding:6px 10px;}#guc-casos #guc-open-modal{order:3;}}
+@media(max-width:600px){#guc-casos .guc-header{flex-direction:column;align-items:flex-start;}#guc-casos .guc-title{margin-right:0;}#guc-casos .guc-header-controls{width:100%;gap:8px;}#guc-casos .guc-search{width:100%;}#guc-casos .guc-filter-text{display:none;}}

--- a/assets/guc-casos.js
+++ b/assets/guc-casos.js
@@ -4,72 +4,421 @@
     /* =========================
      *  Referencias base (UI)
      * ========================= */
-    let $modal = $('#guc-modal');               // modal crear/editar/ver
-    const $open  = $('#guc-open-modal');
-    const $close = $('.guc-modal-close, #guc-cancel');
+    const $root  = $('#guc-casos');
+    if (!$root.length) return;
+
+    let $modal = $('#guc-casos-modal');               // modal crear/editar/ver
+    const $open  = $root.find('#guc-open-modal');
     const $form  = $('#guc-form-caso');
     const $save  = $('#guc-save');
     const $user  = $('#guc-user-select');
-    const $tbody = $('#guc-cases-table');
+    const $tbody = $root.find('#guc-cases-table');
+    const $searchForm   = $root.find('#guc-search-form');
+    const $searchInput  = $root.find('#guc-search-expediente');
+    const $filterToggle = $root.find('#guc-filter-toggle');
+    const $filterMenu   = $root.find('#guc-filter-menu');
+    const $filterWrapper= $root.find('[data-filter-wrapper]');
+
+    let currentSearch = '';
+    let currentFilter = '';
+    let filterMenuOpen = false;
+
+    function updateSearchUI(){
+      if ($searchInput.length) {
+        $searchInput.val(currentSearch);
+      }
+    }
+
+    function updateFilterUI(){
+      if ($filterToggle.length) {
+        var label = 'Todos';
+        if (currentFilter === 'TAR') label = 'TAR';
+        else if (currentFilter === 'JPRD') label = 'JPRD';
+        $filterToggle.attr('data-filter-value', currentFilter || '');
+        var $label = $filterToggle.find('.guc-filter-text');
+        if ($label.length) { $label.text(label); }
+      }
+      if ($filterWrapper.length) {
+        $filterWrapper.attr('data-filter-active', currentFilter ? '1' : '0');
+      }
+      if ($filterMenu.length) {
+        $filterMenu.find('button[data-filter]').each(function(){
+          var val = $(this).attr('data-filter') || '';
+          var isActive = (val === currentFilter);
+          $(this).toggleClass('is-active', isActive);
+          $(this).attr('aria-checked', isActive ? 'true' : 'false');
+        });
+      }
+    }
+
+    function handleFilterDocClick(e){
+      if (!$filterMenu.length) return;
+      var $target = $(e.target);
+      if ($target.closest('#guc-casos [data-filter-wrapper]').length) return;
+      closeFilterMenu();
+    }
+
+    function handleFilterFocus(e){
+      if (!filterMenuOpen) return;
+      var $target = $(e.target);
+      if ($target.closest('#guc-casos [data-filter-wrapper]').length) return;
+      closeFilterMenu();
+    }
+
+    function handleFilterKeydown(e){
+      var key = e.key || e.keyCode;
+      if (key === 'Escape' || key === 'Esc' || key === 27) {
+        closeFilterMenu();
+      }
+    }
+
+    function openFilterMenu(){
+      if (!$filterMenu.length || !$filterToggle.length) return;
+      if (filterMenuOpen) return;
+      filterMenuOpen = true;
+      $filterToggle.attr('aria-expanded','true');
+      if ($filterWrapper.length) $filterWrapper.addClass('is-open');
+      $filterMenu.removeAttr('hidden');
+      setTimeout(function(){
+        $(document)
+          .on('click.gucFilter', handleFilterDocClick)
+          .on('focusin.gucFilter', handleFilterFocus)
+          .on('keydown.gucFilter', handleFilterKeydown);
+      }, 0);
+      setTimeout(function(){
+        if (!$filterMenu.length) return;
+        var $focusTarget = $filterMenu.find('button.is-active').first();
+        if (!$focusTarget.length) {
+          $focusTarget = $filterMenu.find('button').first();
+        }
+        if ($focusTarget.length) {
+          $focusTarget.trigger('focus');
+        }
+      }, 30);
+    }
+
+    function closeFilterMenu(force){
+      if (!$filterMenu.length || !$filterToggle.length) return;
+      var wasOpen = filterMenuOpen;
+      filterMenuOpen = false;
+      $filterToggle.attr('aria-expanded','false');
+      if ($filterWrapper.length) $filterWrapper.removeClass('is-open');
+      $filterMenu.attr('hidden','hidden');
+      $(document).off('.gucFilter');
+      if (force === true || !wasOpen) return;
+      if ($filterToggle.length) {
+        $filterToggle.trigger('blur');
+      }
+    }
+
+    function applySearch(raw){
+      var next = raw ? String(raw).trim() : '';
+      if (next === currentSearch) {
+        return;
+      }
+      currentSearch = next;
+      updateSearchUI();
+      loadTable();
+    }
+
+    function applyFilter(value){
+      var next = (value === 'TAR' || value === 'JPRD') ? value : '';
+      if (next === currentFilter) {
+        closeFilterMenu();
+        return;
+      }
+      currentFilter = next;
+      updateFilterUI();
+      closeFilterMenu();
+      loadTable();
+    }
+
+    if ($searchForm.length) {
+      $searchForm.on('submit', function(e){
+        e.preventDefault();
+        applySearch($searchInput.length ? $searchInput.val() : '');
+      });
+    }
+
+    if ($searchInput.length) {
+      $searchInput.on('keydown', function(e){
+        if (e.key === 'Escape' || e.key === 'Esc' || e.keyCode === 27) {
+          if (currentSearch) {
+            e.preventDefault();
+            applySearch('');
+          } else {
+            $(this).blur();
+          }
+        }
+      });
+      $searchInput.on('input', function(){
+        var val = $(this).val();
+        if (!val || !String(val).trim()) {
+          if (currentSearch !== '') {
+            applySearch('');
+          }
+        }
+      });
+    }
+
+    if ($filterToggle.length) {
+      $filterToggle.on('click', function(e){
+        e.preventDefault();
+        if (filterMenuOpen) closeFilterMenu();
+        else openFilterMenu();
+      });
+    }
+
+    if ($filterMenu.length) {
+      $filterMenu.on('click', 'button[data-filter]', function(e){
+        e.preventDefault();
+        var val = $(this).attr('data-filter') || '';
+        applyFilter(val);
+      });
+    }
+
 
     // Mover modales a body (evita cortes por overflow)
     if ($modal.length && $modal.parent()[0] !== document.body) {
       $modal = $modal.detach().appendTo('body');
     }
+    const $close = $modal.find('.guc-modal-close, #guc-cancel');
 
-    // Modal "Inicio de caso" (reutilizado para Agregar acción)
-    let $startModal = $('#guc-modal-start');
+    // Modal "Inicio / Acción"
+    let $startModal = $('#guc-casos-modal-start');
     let $startForm  = $('#guc-form-inicio');
     const $startSave   = $('#guc-save-start');
     const $startCancel = $('#guc-cancel-start');
+    const $pdfField    = $('#guc-action-pdf');
+    const $pdfName     = $('#guc-action-pdf-name');
+    const $pdfLink     = $('#guc-action-pdf-open');
+    const $pdfUploadBtn= $('#guc-action-pdf-upload');
+    const $pdfDeleteBtn= $('#guc-action-pdf-delete');
 
     if ($startModal.length && $startModal.parent()[0] !== document.body) {
       $startModal = $startModal.detach().appendTo('body');
     }
     $startModal.removeClass('show').attr('aria-hidden','true').hide();
-    // --- Dirty tracking for start modal ---
+
     let startDirty = false;
+    const START_TITLES = {
+      edit: 'Editar acción',
+      default: 'Registrar acción'
+    };
+
+    function fileNameFromUrl(url){
+      if(!url) return '';
+      try {
+        const clean = url.split('/').pop().split('#')[0].split('?')[0];
+        return decodeURIComponent(clean);
+      } catch(e){
+        return url;
+      }
+    }
+
+    function setPdfInfo(url){
+      if(!$pdfField.length) return;
+      const has = !!url;
+      const safeUrl = url || '';
+      $pdfField.attr('data-has-pdf', has ? '1' : '0');
+      $pdfField.attr('data-current-pdf', safeUrl);
+      if ($pdfName.length) {
+        $pdfName.text(has ? fileNameFromUrl(safeUrl) : 'Sin archivo adjunto');
+      }
+      if ($pdfLink.length) {
+        if (has) {
+          $pdfLink.attr('href', safeUrl).removeAttr('hidden');
+        } else {
+          $pdfLink.attr('href', '#').attr('hidden', true);
+        }
+      }
+      if ($pdfUploadBtn.length) {
+        $pdfUploadBtn.attr('data-has-pdf', has ? '1' : '0');
+        $pdfUploadBtn.toggleClass('has-pdf', has);
+      }
+      if ($pdfDeleteBtn.length) {
+        $pdfDeleteBtn.prop('disabled', !has);
+      }
+    }
+
+    function showPdfField(show){
+      if(!$pdfField.length) return;
+      $pdfField.toggleClass('guc-hidden', !show);
+      $pdfField.attr('aria-hidden', show ? 'false' : 'true');
+      if (!show) {
+        setPdfInfo('');
+        $startModal.removeAttr('data-edit-section data-edit-case');
+      }
+    }
+
+    function setStartModalMode(mode){
+      const key = (mode === 'edit') ? 'edit' : 'default';
+      $startModal.attr('data-mode', key);
+      $startModal.find('.guc-modal-header h3').text(START_TITLES[key]);
+      showPdfField(mode === 'edit');
+    }
+
+    function resetStartModal(){
+      startDirty = false;
+      $startModal.removeAttr('data-target-section data-edit-row data-mode data-edit-case data-edit-section');
+      if ($startForm[0]) {
+        $startForm[0].reset();
+      }
+      setPdfInfo('');
+      showPdfField(false);
+    }
+
     $startForm.on('input change', 'input, textarea', function(){ startDirty = true; });
+
+    if ($pdfUploadBtn.length) {
+      $pdfUploadBtn.on('click', function(){
+        if ($startModal.attr('data-mode') !== 'edit') return;
+        const rowId = $startModal.attr('data-edit-row');
+        const section = $startModal.attr('data-edit-section');
+        const caseId = $startModal.attr('data-edit-case');
+        if (!rowId || !section) return;
+        const $btn = $(this);
+        const $input = $('<input type="file" accept="application/pdf" style="display:none">');
+        $('body').append($input);
+        $input.on('change', function(){
+          if (!this.files || !this.files[0]) { $input.remove(); return; }
+          $btn.prop('disabled', true).attr('data-loading','1');
+          doPdfUpload(section, rowId, this.files[0]).done(function(res){
+            if (res && res.success) {
+              const nextUrl = (res.data && res.data.pdf_url) ? res.data.pdf_url : '';
+              setPdfInfo(nextUrl);
+              if (caseId) refreshSectionFor(caseId, section);
+            } else {
+              const message = (res && res.data && res.data.message) ? res.data.message : 'No se pudo subir el PDF';
+              alert(message);
+            }
+          }).fail(function(){
+            alert('Error de conexión al subir PDF');
+          }).always(function(){
+            $btn.prop('disabled', false).removeAttr('data-loading');
+            $input.remove();
+          });
+        }).trigger('click');
+      });
+    }
+
+    if ($pdfDeleteBtn.length) {
+      $pdfDeleteBtn.on('click', function(){
+        const $btn = $(this);
+        if ($btn.prop('disabled')) return;
+        const rowId = $startModal.attr('data-edit-row');
+        const section = $startModal.attr('data-edit-section');
+        const caseId = $startModal.attr('data-edit-case');
+        if (!rowId || !section) return;
+        if (!confirm('¿Eliminar el PDF de esta acción?')) return;
+        $btn.attr('data-loading','1');
+        doPdfClear(section, rowId).done(function(res){
+          if (res && res.success){
+            setPdfInfo('');
+            if (caseId) refreshSectionFor(caseId, section);
+          } else {
+            const message = (res && res.data && res.data.message) ? res.data.message : 'No se pudo eliminar el PDF';
+            alert(message);
+            $btn.prop('disabled', false);
+          }
+        }).fail(function(){
+          alert('Error de conexión al eliminar PDF');
+          $btn.prop('disabled', false);
+        }).always(function(){
+          $btn.removeAttr('data-loading');
+        });
+      });
+    }
+
     function reallyCloseStart(){
       $startModal.removeClass('show').attr('aria-hidden','true').hide();
-      $('body').removeClass('guc-no-scroll');
-      $startModal.removeAttr('data-target-section');
-      startDirty = false;
+      $('body').removeClass('guc-casos-no-scroll');
+      resetStartModal();
     }
-    function closeStart(){
-      if (startDirty){
+
+    function closeStart(force){
+      if (force && typeof force.preventDefault === 'function') {
+        force.preventDefault();
+        force = false;
+      }
+      const shouldForce = force === true;
+      if (!shouldForce && startDirty && $startModal.attr('data-mode') !== 'view'){
         if(!confirm('Tienes cambios sin guardar. ¿Cerrar de todos modos?')) return;
       }
       reallyCloseStart();
     }
-    $startModal.find('.guc-modal-close').off('click').on('click', closeStart);
 
-
-    function openStart(){ $startModal.addClass('show').attr('aria-hidden','false').show(); $('body').addClass('guc-no-scroll'); }
-    function closeStart(){ $startModal.removeClass('show').attr('aria-hidden','true').hide();
-    // --- Dirty tracking for start modal ---
-    let startDirty = false;
-    $startForm.on('input change', 'input, textarea', function(){ startDirty = true; });
-    function reallyCloseStart(){
-      $startModal.removeClass('show').attr('aria-hidden','true').hide();
-      $('body').removeClass('guc-no-scroll');
-      $startModal.removeAttr('data-target-section');
+    function openStart(mode){
+      setStartModalMode(mode);
       startDirty = false;
+      $startModal.addClass('show').attr('aria-hidden','false').show();
+      $('body').addClass('guc-casos-no-scroll');
     }
-    function closeStart(){
-      if (startDirty){
-        if(!confirm('Tienes cambios sin guardar. ¿Cerrar de todos modos?')) return;
-      }
-      reallyCloseStart();
-    }
+
     $startModal.find('.guc-modal-close').off('click').on('click', closeStart);
- $('body').removeClass('guc-no-scroll'); $startModal.removeAttr('data-target-section'); }
     $startCancel.on('click', closeStart);
     $startModal.on('mousedown', function(e){
       const $dialog = $startModal.find('.guc-modal-dialog');
       if ($dialog.is(e.target) || $dialog.has(e.target).length) return;
       closeStart();
     });
+
+    // Modal estado del caso
+    let $statusModal = $('#guc-casos-modal-status');
+    let $statusForm  = $('#guc-form-status');
+    const $statusSave   = $('#guc-save-status');
+    const $statusCancel = $('#guc-cancel-status');
+    let statusDirty = false;
+
+    if ($statusModal.length && $statusModal.parent()[0] !== document.body) {
+      $statusModal = $statusModal.detach().appendTo('body');
+      $statusForm = $('#guc-form-status');
+    }
+    if ($statusModal.length) {
+      $statusModal.removeClass('show').attr('aria-hidden','true').hide();
+    }
+
+    function resetStatusModal(){
+      statusDirty = false;
+      if ($statusForm && $statusForm[0]) {
+        $statusForm[0].reset();
+      }
+    }
+
+    function closeStatus(force){
+      if (!$statusModal.length) return;
+      if (force && typeof force.preventDefault === 'function') {
+        force.preventDefault();
+        force = false;
+      }
+      const shouldForce = force === true;
+      if (!shouldForce && statusDirty){
+        if (!confirm('Tienes cambios sin guardar. ¿Cerrar de todos modos?')) return;
+      }
+      $statusModal.removeClass('show').attr('aria-hidden','true').hide();
+      if (!$modal.hasClass('show') && !$startModal.hasClass('show')) {
+        $('body').removeClass('guc-casos-no-scroll');
+      }
+      resetStatusModal();
+    }
+
+    function openStatus(){
+      if (!$statusModal.length) return;
+      statusDirty = false;
+      $statusModal.addClass('show').attr('aria-hidden','false').show();
+      $('body').addClass('guc-casos-no-scroll');
+    }
+
+    if ($statusModal.length){
+      $statusModal.find('.guc-modal-close').off('click').on('click', closeStatus);
+      $statusCancel.on('click', closeStatus);
+      $statusModal.on('mousedown', function(e){
+        const $dialog = $statusModal.find('.guc-modal-dialog');
+        if ($dialog.is(e.target) || $dialog.has(e.target).length) return;
+        closeStatus();
+      });
+      $statusForm.on('input change', 'input, select', function(){ statusDirty = true; });
+    }
 
     /* =========================
      *  Modal general (casos)
@@ -81,16 +430,19 @@
       if ($form[0]) $form[0].reset();
       $form.find('[name=id]').val('');
       $form.find('[name=entidad],[name=expediente]').val('');
+      $form.find('[name=case_type]').prop('disabled', false);
+      $form.find('input, textarea, select').prop('disabled', false).removeClass('guc-readonly');
+      $user.prop('disabled', false);
       setDirty(false);
     }
 
-    function openModal(){ $modal.addClass('show').attr('aria-hidden','false').show(); $('body').addClass('guc-no-scroll'); }
+    function openModal(){ $modal.addClass('show').attr('aria-hidden','false').show(); $('body').addClass('guc-casos-no-scroll'); }
     function closeModal(){
       if (dirty && mode !== 'view') {
         if (!confirm('Tienes cambios sin guardar. ¿Cerrar de todos modos?')) return;
       }
       $modal.removeClass('show').attr('aria-hidden','true').hide();
-      $('body').removeClass('guc-no-scroll');
+      $('body').removeClass('guc-casos-no-scroll');
     }
 
     function setMode(m){
@@ -100,18 +452,28 @@
         m === 'create' ? 'Crear nuevo caso' :
         m === 'edit'   ? 'Editar caso'      : 'Ver caso'
       );
-      $form.find('input, textarea, select').prop('disabled', readonly).toggleClass('guc-readonly', readonly);
+      if (readonly) {
+        $form.find('input, textarea, select').prop('disabled', true).addClass('guc-readonly');
+      } else {
+        $form.find('input, textarea, select').prop('disabled', false).removeClass('guc-readonly');
+        const disableFixed = (m !== 'create');
+        $user.prop('disabled', disableFixed);
+        $form.find('[name=case_type]').prop('disabled', disableFixed);
+        $form.find('[name=entidad],[name=expediente]').prop('disabled', true).addClass('guc-readonly');
+      }
       $save.toggle(m !== 'view').text(m === 'edit' ? 'Actualizar' : 'Guardar');
     }
 
     function fillForm(d){
       $form.find('[name=id]').val(d.id || '');
-      $form.find('[name=nomenclatura]').val(d.nomenclatura || '');
+      const nomen = d.nomenclatura || d.nomenclature || '';
+      $form.find('[name=nomenclatura]').val(nomen);
       $form.find('[name=convocatoria]').val(d.convocatoria || '');
       $form.find('[name=expediente]').val(d.exediente || d.expediente || '');
       $form.find('[name=entidad]').val(d.entidad || '');
       $form.find('[name=objeto]').val(d.objeto || '');
       $form.find('[name=descripcion]').val(d.descripcion || '');
+      $form.find('[name=case_type]').val(d.case_type || '');
       if ($user.length && d.user_id) $user.val(String(d.user_id));
     }
 
@@ -119,17 +481,44 @@
     /* =========================
      *  Helpers: state & UX
      * ========================= */
+    const STORAGE_KEY = 'gucCasosState';
+
+    function readStoredState(){
+      try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object') return parsed;
+      } catch(e){}
+      return null;
+    }
+
+    function rememberState(state){
+      try {
+        if (!state) return;
+        const payload = {
+          openCases: Array.isArray(state.openCases) ? state.openCases : [],
+          panels: state.panels && typeof state.panels === 'object' ? state.panels : {},
+          secretariaBucket: state.secretariaBucket && typeof state.secretariaBucket === 'object' ? state.secretariaBucket : {}
+        };
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+      } catch(e){}
+    }
+
+    updateSearchUI();
+    updateFilterUI();
+    closeFilterMenu(true);
+
     function captureState(){
-      const state = { openCases: [], panels:{}, secretariaBucket:{} };
-      $('tr.guc-subrow').each(function(){
-        const caseId = $(this).attr('data-parent');
+      const state = { openCases: [], panels:{}, secretariaBucket:{}, search: currentSearch || '', filter: currentFilter || '' };
+      $root.find('tr.guc-subrow').each(function(){
+        const caseId = String($(this).attr('data-parent') || '');
         if(!caseId) return;
-        state.openCases.push(caseId);
+        if (!state.openCases.includes(caseId)) state.openCases.push(caseId);
         state.panels[caseId] = [];
         $(this).find('.guc-sec .guc-toggle').each(function(idx){
           state.panels[caseId][idx] = ($(this).attr('aria-expanded') === 'true');
         });
-        // record current secretaria bucket if present
         const $secWrap = $(this).find('.guc-subtable-wrap[data-section="secretaria"]');
         const b = $secWrap.attr('data-bucket');
         if (b) state.secretariaBucket[caseId] = b;
@@ -137,43 +526,121 @@
       return state;
     }
 
-    function restoreState(state){
-      if(!state || !state.openCases) return;
-      state.openCases.forEach(function(caseId){
-        const $row = $('.guc-start[data-id="'+caseId+'"]').first().closest('tr');
-        if(!$row.length) return;
-        const $sub = ensureSubrow($row, caseId);
-        // restore secretaria bucket/title if remembered
-        if (state.secretariaBucket[caseId]) {
-          const b = state.secretariaBucket[caseId];
-          const $wrap = $sub.find('.guc-subtable-wrap[data-section="secretaria"]');
-          $wrap.attr('data-bucket', b);
-          $sub.find('[data-secretaria-title]').text(b === 'sec_arbitral' ? 'Secretaría Arbitral' : 'Secretaría General');
-        }
-        // render all wraps
-        $sub.find('.guc-subtable-wrap').each(function(){ renderSection($(this)); });
-
-        // restore panel expanded/collapsed
-        const arr = state.panels[caseId] || [];
-        $sub.find('.guc-sec .guc-toggle').each(function(idx){
-          const wantOpen = (arr[idx] !== false); // default open
-          const $btn = $(this);
-          const $panel = $btn.next('.guc-panel');
-          $btn.attr('aria-expanded', wantOpen ? 'true' : 'false');
-          $btn.find('.guc-caret').text(wantOpen ? '▴' : '▾');
-          if (wantOpen) $panel.show(); else $panel.hide();
-        });
+    function applyPanelState($sub, arr){
+      const cfg = arr || [];
+      $sub.find('.guc-sec .guc-toggle').each(function(idx){
+        const wantOpen = (cfg[idx] !== false);
+        const $btn = $(this);
+        const $panel = $btn.next('.guc-panel');
+        $btn.attr('aria-expanded', wantOpen ? 'true' : 'false');
+        $btn.find('.guc-caret').text(wantOpen ? '▴' : '▾');
+        if (wantOpen) $panel.show(); else $panel.hide();
       });
-      enhanceActionButtons($('#guc-cases-table'));
     }
 
-    function enhanceActionButtons($scope){
-      const S = $scope || $(document);
-      S.find('.guc-view').each(function(){ if(!$(this).text().trim()) $(this).html('👁 Ver'); });
-      S.find('.guc-edit').each(function(){ if(!$(this).text().trim()) $(this).html('✎ Editar'); });
-      S.find('.guc-del').each(function(){ if(!$(this).text().trim()) $(this).html('🗑 Eliminar'); });
-      S.find('.guc-upload').each(function(){ if(!$(this).text().trim()) $(this).html('⤴ Subir PDF'); });
-      S.find('.guc-pdf').each(function(){ if(!$(this).text().trim()) $(this).html('📄 PDF'); });
+    function setCaseHasActions(caseId, has){
+      const cid = String(caseId);
+      const $btn = $root.find('.guc-start[data-id="'+cid+'"]').first();
+      if ($btn.length) {
+        $btn.text(has ? 'Agregar acción' : 'Iniciar caso');
+        $btn.closest('tr').attr('data-has-actions', has ? '1' : '0');
+      }
+    }
+
+    function updateCaseHasActions($sub){
+      if(!$sub || !$sub.length) return;
+      const caseId = $sub.attr('data-parent');
+      if(!caseId) return;
+      const has = $sub.find('tbody tr[data-row-id]').length > 0;
+      setCaseHasActions(caseId, has);
+    }
+
+    function resolveSectionKey($btn){
+      let section = $btn.data('section');
+      if(!section){
+        const $wrap = $btn.closest('.guc-subtable-wrap');
+        const secKey = $wrap.data('section');
+        if (secKey === 'secretaria') section = $wrap.attr('data-bucket') || 'sec_general';
+        else section = (secKey === 'pre') ? 'pre' : 'arb';
+      }
+      return section;
+    }
+
+    function refreshSectionFor(caseId, sectionKey){
+      if(!caseId) return;
+      const cid = String(caseId);
+      const $sub = $root.find('tr.guc-subrow[data-parent="'+cid+'"]').first();
+      if(!$sub.length) return;
+      let $wrap;
+      if (sectionKey === 'pre') {
+        $wrap = $sub.find('.guc-subtable-wrap[data-section="pre"]');
+      } else if (sectionKey === 'arb') {
+        $wrap = $sub.find('.guc-subtable-wrap[data-section="arb"]');
+      } else {
+        $wrap = $sub.find('.guc-subtable-wrap[data-section="secretaria"]');
+        if ($wrap.length) {
+          $wrap.attr('data-bucket', sectionKey);
+          $sub.find('[data-secretaria-title]').text(sectionKey === 'sec_arbitral' ? 'Secretaría Arbitral' : 'Secretaría General');
+        }
+      }
+      if ($wrap && $wrap.length) {
+        renderSection($wrap);
+      }
+    }
+
+    function openCaseRow($row, caseId, state){
+      if(!$row || !$row.length) return null;
+      const cid = String(caseId);
+      const $sub = ensureSubrow($row, cid);
+      if(!$sub || !$sub.length) return null;
+
+      const secBucket = state && state.secretariaBucket ? state.secretariaBucket[cid] : undefined;
+      if (secBucket) {
+        const $wrap = $sub.find('.guc-subtable-wrap[data-section="secretaria"]');
+        $wrap.attr('data-bucket', secBucket);
+        $sub.find('[data-secretaria-title]').text(secBucket === 'sec_arbitral' ? 'Secretaría Arbitral' : 'Secretaría General');
+      }
+
+      const $preWrap = $sub.find('.guc-subtable-wrap[data-section="pre"]');
+      const $secWrap = $sub.find('.guc-subtable-wrap[data-section="secretaria"]');
+      const $arbWrap = $sub.find('.guc-subtable-wrap[data-section="arb"]');
+
+      renderSection($preWrap);
+      renderSection($secWrap);
+      renderSection($arbWrap);
+
+      const panelState = (state && state.panels) ? state.panels[cid] : undefined;
+      applyPanelState($sub, panelState);
+      return $sub;
+    }
+
+    function restoreState(state){
+      const stored = state || readStoredState() || { openCases:[], panels:{}, secretariaBucket:{}, search:'', filter:'' };
+      currentSearch = stored.search ? String(stored.search) : '';
+      const storedFilter = stored.filter ? String(stored.filter) : '';
+      currentFilter = (storedFilter === 'TAR' || storedFilter === 'JPRD') ? storedFilter : '';
+      updateSearchUI();
+      updateFilterUI();
+      const requested = new Set((stored.openCases || []).map(String));
+      const opened = new Set();
+
+      requested.forEach(function(cid){
+        const $row = $tbody.find('tr[data-id="'+cid+'"]').first();
+        if(!$row.length) return;
+        if (openCaseRow($row, cid, stored)) {
+          opened.add(cid);
+        }
+      });
+
+      $tbody.find('tr[data-id][data-has-actions="1"]').each(function(){
+        const cid = String($(this).data('id'));
+        if(opened.has(cid)) return;
+        if (openCaseRow($(this), cid, stored)) {
+          opened.add(cid);
+        }
+      });
+
+      rememberState(captureState());
     }
 
 
@@ -181,12 +648,18 @@
      *  Datos (AJAX)
      * ========================= */
     function loadTable(){
-      const _state = captureState();
-      $.post(GUC_CASOS.ajax, { action:'guc_list_cases', nonce:GUC_CASOS.nonce }, function(res){
+      closeFilterMenu();
+      const runtimeState = captureState();
+      rememberState(runtimeState);
+      $.post(GUC_CASOS.ajax, {
+        action:'guc_list_cases',
+        nonce:GUC_CASOS.nonce,
+        search: currentSearch,
+        filter: currentFilter
+      }, function(res){
         if (res && res.success) {
           $tbody.html(res.data.html);
-          enhanceActionButtons($tbody);
-          restoreState(_state);
+          restoreState(runtimeState.openCases && runtimeState.openCases.length ? runtimeState : null);
         } else {
           $tbody.html('<tr><td colspan="6" class="guc-empty">Error al cargar.</td></tr>');
         }
@@ -195,16 +668,28 @@
       });
     }
 
-    function loadUsers(selectedId){
-      return $.post(GUC_CASOS.ajax, { action:'guc_list_users', nonce:GUC_CASOS.nonce }, function(res){
+    function loadUsers(selectedId, includeId){
+      const payload = { action:'guc_list_users', nonce:GUC_CASOS.nonce };
+      if (includeId) payload.include_id = includeId;
+      return $.post(GUC_CASOS.ajax, payload, function(res){
         if (res && res.success) {
           $user.empty().append('<option value="">— Selecciona un usuario —</option>');
           res.data.forEach(function(u){
             $user.append('<option value="'+u.id+'" data-entity="'+(u.entity||'')+'" data-expediente="'+(u.expediente||'')+'">'+(u.username || ('ID '+u.id))+'</option>');
           });
-          if (selectedId) $user.val(String(selectedId));
+          if (selectedId) {
+            const sid = String(selectedId);
+            if (!$user.find('option[value="'+sid+'"]').length && res.data){
+              const current = res.data.find(function(u){ return String(u.id) === sid; });
+              if (current) {
+                $user.append('<option value="'+current.id+'" data-entity="'+(current.entity||'')+'" data-expediente="'+(current.expediente||'')+'">'+(current.username || ('ID '+current.id))+'</option>');
+              }
+            }
+            $user.val(sid);
+          }
         } else {
-          alert(res?.data?.message || 'No se pudieron cargar usuarios');
+          const message = (res && res.data && res.data.message) ? res.data.message : 'No se pudieron cargar usuarios';
+          alert(message);
         }
       }, 'json');
     }
@@ -216,16 +701,19 @@
 
     $open.on('click', async function(){
       resetForm(); setMode('create'); await loadUsers('');
-      $form.find('[name=entidad],[name=expediente]').prop('disabled', true).addClass('guc-readonly');
       openModal();
     });
     $close.on('click', closeModal);
 
     $(document).on('keydown.gucCasos', function(e){
-      if (e.key === 'Escape' && ($modal.hasClass('show') || $startModal.hasClass('show'))) { closeModal(); closeStart(); }
+      if (e.key === 'Escape') {
+        if ($statusModal.length && $statusModal.hasClass('show')) { closeStatus(); }
+        if ($startModal.hasClass('show')) { closeStart(); }
+        if ($modal.hasClass('show')) { closeModal(); }
+      }
     });
     $modal.on('mousedown', function(e){
-      const $dialog = $('.guc-modal-dialog').first();
+      const $dialog = $modal.find('.guc-modal-dialog').first();
       if ($dialog.is(e.target) || $dialog.has(e.target).length) return;
       closeModal();
     });
@@ -249,11 +737,61 @@
       $.post(GUC_CASOS.ajax, { action, nonce:GUC_CASOS.nonce, data }, function(res){
         $save.prop('disabled', false);
         if (res && res.success) { setDirty(false); closeModal(); loadTable(); }
-        else alert(res?.data?.message || 'Error al guardar');
+        else {
+          const message = (res && res.data && res.data.message) ? res.data.message : 'Error al guardar';
+          alert(message);
+        }
       }, 'json').fail(function(){
         $save.prop('disabled', false); alert('Error de conexión');
       });
     });
+
+    // estado del caso
+    $tbody.on('click', '.guc-status', function(){
+      if (!$statusModal.length) return;
+      const id = $(this).data('id');
+      if (!id) return;
+      $.post(GUC_CASOS.ajax, { action:'guc_get_case', nonce:GUC_CASOS.nonce, id }, function(res){
+        if (!(res && res.success)) { alert('No se pudo cargar el caso'); return; }
+        const d = res.data || {};
+        resetStatusModal();
+        if ($statusForm.length) {
+          $statusForm.find('[name=case_id]').val(d.id || '');
+          $statusForm.find('[name=estado]').val(d.estado || '');
+          const fecha = d.estado_fecha || '';
+          if (fecha) {
+            const iso = fecha.replace(' ', 'T').slice(0,16);
+            $statusForm.find('[name=estado_fecha]').val(iso);
+          }
+        }
+        statusDirty = false;
+        openStatus();
+      }, 'json').fail(function(){ alert('Error de conexión'); });
+    });
+
+    if ($statusSave.length){
+      $statusSave.on('click', function(){
+        if (!$statusForm.length) return;
+        const data = Object.fromEntries(new FormData($statusForm[0]).entries());
+        if (!data.case_id) { alert('Caso inválido'); return; }
+        if (!data.estado) { alert('Selecciona un estado'); return; }
+        $statusSave.prop('disabled', true);
+        $.post(GUC_CASOS.ajax, { action:'guc_update_case_status', nonce:GUC_CASOS.nonce, data }, function(res){
+          $statusSave.prop('disabled', false);
+          if (res && res.success) {
+            statusDirty = false;
+            closeStatus(true);
+            loadTable();
+          } else {
+            const message = (res && res.data && res.data.message) ? res.data.message : 'No se pudo actualizar el estado';
+            alert(message);
+          }
+        }, 'json').fail(function(){
+          $statusSave.prop('disabled', false);
+          alert('Error de conexión');
+        });
+      });
+    }
 
     // ver/editar/eliminar
     $tbody.on('click', '.guc-view, .guc-edit, .guc-del', function(){
@@ -263,7 +801,10 @@
         if (!confirm('¿Eliminar este caso?')) return;
         $.post(GUC_CASOS.ajax, { action:'guc_delete_case', nonce:GUC_CASOS.nonce, id }, function(res){
           if (res && res.success) loadTable();
-          else alert(res?.data?.message || 'No se pudo eliminar');
+          else {
+            const message = (res && res.data && res.data.message) ? res.data.message : 'No se pudo eliminar';
+            alert(message);
+          }
         }, 'json').fail(function(){ alert('Error de conexión al eliminar'); });
         return;
       }
@@ -271,7 +812,7 @@
       $.post(GUC_CASOS.ajax, { action:'guc_get_case', nonce:GUC_CASOS.nonce, id }, async function(res){
         if (!(res && res.success)) { alert('No se pudo cargar el caso'); return; }
         const d = res.data || {};
-        resetForm(); await loadUsers(d.user_id); fillForm(d); $form.find('[name=entidad],[name=expediente]').prop('disabled', true).addClass('guc-readonly');
+        resetForm(); await loadUsers(d.user_id, d.user_id); fillForm(d);
         if ($(this).hasClass('guc-view')) setMode('view'); else setMode('edit');
         openModal(); setDirty(false);
       }.bind(this), 'json').fail(function(){ alert('Error de conexión al cargar'); });
@@ -286,7 +827,7 @@
     $tbody.on('click', '.guc-start', function(){
       $lastStartRow = $(this).closest('tr');
       const id = $(this).data('id');
-      if ($startForm[0]) $startForm[0].reset();
+      resetStartModal();
       $startForm.find('[name=case_id]').val(id || '');
 
       // autollenar fecha actual
@@ -359,7 +900,11 @@
         const bucket = $wrap.attr('data-bucket'); // sec_arbitral | sec_general
         const doList = function(bucketKey){
           $.post(GUC_CASOS.ajax, { action:'guc_list_section', nonce:GUC_CASOS.nonce, case_id:caseId, section: bucketKey }, function(res){
-            if (res && res.success) { $wrap.html(res.data.html); enhanceActionButtons($wrap); }
+            if (res && res.success) {
+              $wrap.html(res.data.html);
+              updateCaseHasActions($wrap.closest('tr.guc-subrow'));
+              rememberState(captureState());
+            }
             else $wrap.html('<div class="guc-empty">No se pudo cargar Secretaría.</div>');
           }, 'json').fail(function(){ $wrap.html('<div class="guc-empty">Error de conexión.</div>'); });
         };
@@ -378,30 +923,35 @@
       } else {
         const key = section === 'pre' ? 'pre' : 'arb';
         $.post(GUC_CASOS.ajax, { action:'guc_list_section', nonce:GUC_CASOS.nonce, case_id:caseId, section:key }, function(res){
-          if (res && res.success) { $wrap.html(res.data.html); enhanceActionButtons($wrap); }
+          if (res && res.success) {
+            $wrap.html(res.data.html);
+            updateCaseHasActions($wrap.closest('tr.guc-subrow'));
+            rememberState(captureState());
+          }
           else $wrap.html('<div class="guc-empty">No se pudo cargar.</div>');
         }, 'json').fail(function(){ $wrap.html('<div class="guc-empty">Error de conexión.</div>'); });
       }
     }
 
     // acordeón
-    $(document).on('click', '.guc-toggle', function () {
+    $root.on('click', '.guc-toggle', function () {
       const $btn = $(this);
       const $panel = $btn.next('.guc-panel');
       const expanded = $btn.attr('aria-expanded') === 'true';
       $btn.attr('aria-expanded', !expanded);
       $btn.find('.guc-caret').text(expanded ? '▾' : '▴');
       if (expanded) { $panel.slideUp(160); } else { $panel.slideDown(160); }
+      rememberState(captureState());
     });
 
     /* ==========================================================
      *  Botón "Agregar acción" (marca el destino)
      * ========================================================== */
-    $(document).on('click', '.guc-add-action', function(){
+    $root.on('click', '.guc-add-action', function(){
       const sectionKey = $(this).data('section'); // pre | sec_arbitral | sec_general | arb
       const caseId = $(this).data('case-id');
 
-      if ($startForm[0]) $startForm[0].reset();
+      resetStartModal();
       $startForm.find('[name=case_id]').val(caseId);
       $startModal.attr('data-target-section', sectionKey); // <- destino explícito
 
@@ -418,25 +968,28 @@
     /* ==========================================================
      *  Editar fila de acción (reutiliza el mismo modal)
      * ========================================================== */
-    $(document).on('click', '.guc-row-edit', function(){
+    $root.on('click', '.guc-row-edit', function(){
       const $btn = $(this);
       const $row = $btn.closest('tr');
       const rowId = $row.data('row-id');
       if(!rowId) return;
       // infer section from container if not provided in data-section
-      let section = $btn.data('section');
-      if(!section){
-        const $wrap = $btn.closest('.guc-subtable-wrap');
-        const secKey = $wrap.data('section'); // pre | secretaria | arb
-        if (secKey === 'secretaria') section = $wrap.attr('data-bucket') || 'sec_general';
-        else section = (secKey === 'pre') ? 'pre' : 'arb';
-      }
+      const section = resolveSectionKey($btn);
 
       $.post(GUC_CASOS.ajax, { action:'guc_get_section_row', nonce:GUC_CASOS.nonce, section, row_id: rowId }, function(res){
-        if(!(res && res.success)){ alert(res?.data?.message || 'No se pudo obtener la fila'); return; }
+        if(!(res && res.success)){
+          const message = (res && res.data && res.data.message) ? res.data.message : 'No se pudo obtener la fila';
+          alert(message);
+          return;
+        }
         const d = res.data || {};
-        if ($startForm[0]) $startForm[0].reset();
-        $startModal.attr('data-target-section', section).attr('data-edit-row', String(rowId));
+        resetStartModal();
+        $startModal.attr('data-target-section', section)
+                   .attr('data-edit-row', String(rowId))
+                   .attr('data-edit-section', section);
+        if (d.case_id) {
+          $startModal.attr('data-edit-case', String(d.case_id));
+        }
         $startForm.find('[name=case_id]').val(d.case_id || '');
         $startForm.find('[name=situacion]').val(d.situacion || '');
         $startForm.find('[name=motivo]').val(d.motivo || '');
@@ -445,8 +998,33 @@
           const isoLocal = d.fecha.replace(' ', 'T').slice(0,16);
           $startForm.find('[name=fecha]').val(isoLocal);
         }
-        openStart();
+        const pdfUrl = d.pdf_url || d.pdf || d.file_url || d.attachment_url || '';
+        showPdfField(true);
+        setPdfInfo(pdfUrl);
+        openStart('edit');
       }, 'json').fail(function(){ alert('Error de conexión'); });
+    });
+
+    $root.on('click', '.guc-row-del', function(){
+      const $btn = $(this);
+      const section = resolveSectionKey($btn);
+      const rowId = $btn.closest('tr').data('row-id');
+      if (!rowId || !section) return;
+      const $wrap = $btn.closest('.guc-subtable-wrap');
+      if (!confirm('¿Eliminar esta acción?')) return;
+      $btn.prop('disabled', true);
+      $.post(GUC_CASOS.ajax, { action:'guc_delete_section_row', nonce:GUC_CASOS.nonce, section, row_id: rowId }, function(res){
+        if (res && res.success){
+          renderSection($wrap);
+        } else {
+          const message = (res && res.data && res.data.message) ? res.data.message : 'No se pudo eliminar la acción';
+          alert(message);
+          $btn.prop('disabled', false);
+        }
+      }, 'json').fail(function(){
+        alert('Error de conexión al eliminar');
+        $btn.prop('disabled', false);
+      });
     });
 
 
@@ -459,9 +1037,9 @@
       const data = Object.fromEntries(new FormData($startForm[0]).entries());
 
       // validaciones comunes
-      if (!data.case_id)           { alert('ID del caso no válido.'); return; }
-      if (!data.situacion?.trim()) { alert('Describe la situación.'); return; }
-      if (!data.motivo?.trim())    { alert('Indica el motivo.'); return; }
+      if (!data.case_id) { alert('ID del caso no válido.'); return; }
+      if (!data.situacion || !String(data.situacion).trim()) { alert('Describe la situación.'); return; }
+      if (!data.motivo || !String(data.motivo).trim())    { alert('Indica el motivo.'); return; }
 
       $startSave.prop('disabled', true);
 
@@ -490,13 +1068,18 @@
           if (editingRow) { endpoint = 'guc_update_section_row'; payload['row_id'] = editingRow; }
           $.post(GUC_CASOS.ajax, Object.assign({ action:endpoint }, payload), function(res){
             $startSave.prop('disabled', false);
-            if (!(res && res.success)) { alert(res?.data?.message || (editingRow?'No se pudo actualizar la acción':'No se pudo registrar la acción')); return; }
+            if (!(res && res.success)) {
+              var fallback = editingRow ? 'No se pudo actualizar la acción' : 'No se pudo registrar la acción';
+              var message = (res && res.data && res.data.message) ? res.data.message : fallback;
+              alert(message);
+              return;
+            }
 
-            closeStart(); // cerrar modal y limpiar destino
-            $startModal.removeAttr('data-target-section').removeAttr('data-edit-row');
+            startDirty = false;
+            closeStart(true); // cerrar modal y limpiar destino
 
             // refrescar SOLO la subtabla correspondiente
-            const $sub = $('tr.guc-subrow[data-parent="'+data.case_id+'"]');
+            const $sub = $root.find('tr.guc-subrow[data-parent="'+data.case_id+'"]').first();
             let $wrap;
             if (finalBucket === 'pre') {
               $wrap = $sub.find('.guc-subtable-wrap[data-section="pre"]');
@@ -505,10 +1088,14 @@
             } else {
               // secretaría
               $wrap = $sub.find('.guc-subtable-wrap[data-section="secretaria"]');
-              $wrap.attr('data-bucket', finalBucket);
-              $sub.find('[data-secretaria-title]').text(finalBucket === 'sec_arbitral' ? 'Secretaría Arbitral' : 'Secretaría General');
+              if ($wrap.length) {
+                $wrap.attr('data-bucket', finalBucket);
+                $sub.find('[data-secretaria-title]').text(finalBucket === 'sec_arbitral' ? 'Secretaría Arbitral' : 'Secretaría General');
+              }
             }
-            renderSection($wrap);
+            if ($wrap && $wrap.length) {
+              renderSection($wrap);
+            }
           }, 'json').fail(function(){
             $startSave.prop('disabled', false);
             alert('Error de conexión al registrar la acción');
@@ -518,16 +1105,21 @@
         return; // IMPORTANTE: no ejecutar la rama de iniciar caso
       }
 
-      // ---------- Rama B: INICIAR CASO ---------- }
+      // ---------- Rama B: INICIAR CASO ----------
 
       $.post(GUC_CASOS.ajax, { action:'guc_create_case_event', nonce:GUC_CASOS.nonce, data }, function(res){
         $startSave.prop('disabled', false);
-        if (!(res && res.success)) { alert(res?.data?.message || 'No se pudo registrar el evento'); return; }
+        if (!(res && res.success)) {
+          const message = (res && res.data && res.data.message) ? res.data.message : 'No se pudo registrar el evento';
+          alert(message);
+          return;
+        }
 
-        closeStart();
+        startDirty = false;
+        closeStart(true);
 
         // asegurar subfila
-        const $row = ($lastStartRow && $lastStartRow.length) ? $lastStartRow : $('.guc-start[data-id="'+ data.case_id +'"]').first().closest('tr');
+        const $row = ($lastStartRow && $lastStartRow.length) ? $lastStartRow : $root.find('.guc-start[data-id="'+ data.case_id +'"]').first().closest('tr');
         const $sub = ensureSubrow($row, data.case_id);
 
         // 1) insertar PRIMER registro visible en PRE
@@ -554,126 +1146,69 @@
       });
     });
 
+    function doPdfUpload(section, rowId, file){
+      const fd = new FormData();
+      fd.append('action','guc_upload_pdf');
+      fd.append('nonce', GUC_CASOS.nonce);
+      fd.append('section', section);
+      fd.append('row_id', rowId);
+      fd.append('file', file);
+      return $.ajax({
+        url: GUC_CASOS.ajax,
+        type: 'POST',
+        data: fd,
+        contentType: false,
+        processData: false,
+        dataType: 'json'
+      });
+    }
+
+    function doPdfClear(section, rowId){
+      return $.post(GUC_CASOS.ajax, {
+        action: 'guc_clear_pdf',
+        nonce: GUC_CASOS.nonce,
+        section,
+        row_id: rowId
+      }, null, 'json');
+    }
+
     /* ==========================================================
      *  Subida de PDF (delegado por fila)
      * ========================================================== */
-    $(document).on('click', '.guc-upload', function(){
+    $root.on('click', '.guc-upload', function(){
       const $btn = $(this);
-      const section = $btn.data('section'); // pre | sec_arbitral | sec_general | arb
-      const rowId   = $btn.closest('tr').data('row-id');
-      if (!rowId) return;
+      const section = resolveSectionKey($btn); // pre | sec_arbitral | sec_general | arb
+      const $row = $btn.closest('tr');
+      const rowId   = $row.data('row-id');
+      const caseId  = $row.data('case-id');
+      if (!rowId || !section) return;
+
+      const $wrap = $btn.closest('.guc-subtable-wrap');
 
       const $input = $('<input type="file" accept="application/pdf" style="display:none">');
       $('body').append($input);
       $input.on('change', function(){
         if (!this.files || !this.files[0]) { $input.remove(); return; }
-        const fd = new FormData();
-        fd.append('action','guc_upload_pdf');
-        fd.append('nonce', GUC_CASOS.nonce);
-        fd.append('section', section);
-        fd.append('row_id', rowId);
-        fd.append('file', this.files[0]);
-
-        $btn.prop('disabled', true).text('Subiendo...');
-        $.ajax({
-          url: GUC_CASOS.ajax,
-          type: 'POST',
-          data: fd, contentType:false, processData:false, dataType:'json'
-        }).done(function(res){
+        $btn.prop('disabled', true).attr('data-loading','1');
+        doPdfUpload(section, rowId, this.files[0]).done(function(res){
           if (res && res.success) {
-            $btn.replaceWith('<a class="guc-btn guc-btn-secondary" target="_blank" rel="noopener" href="'+res.data.pdf_url+'">PDF subido</a>');
+            if ($wrap.length) {
+              renderSection($wrap);
+            } else if (caseId) {
+              refreshSectionFor(caseId, section);
+            }
           } else {
-            alert(res?.data?.message || 'No se pudo subir el PDF');
-            $btn.prop('disabled', false).text('Subir PDF');
+            const message = (res && res.data && res.data.message) ? res.data.message : 'No se pudo subir el PDF';
+            alert(message);
           }
         }).fail(function(){
           alert('Error de conexión al subir PDF');
-          $btn.prop('disabled', false).text('Subir PDF');
-        }).always(function(){ $input.remove(); });
+        }).always(function(){
+          $btn.removeAttr('data-loading').prop('disabled', false);
+          $input.remove();
+        });
       }).trigger('click');
     });
-
-
-    /* ==========================================================
-     *  PDF: menú Ver / Reemplazar / Eliminar
-     * ========================================================== */
-    function buildPdfMenu($anchor, opts){
-      $('.guc-pdf-menu').remove(); // close others
-      const menu = $('<div class="guc-pdf-menu" />').css({
-        position:'absolute', zIndex: 100002, background:'#fff', border:'1px solid #eadfce', borderRadius:'8px',
-        boxShadow:'0 8px 20px rgba(0,0,0,.12)', overflow:'hidden'
-      });
-      const mkBtn = (label, cls)=> $('<button type="button" />').addClass(cls).css({display:'block',padding:'8px 12px',border:0,background:'#fff',width:'100%',textAlign:'left',cursor:'pointer'}).text(label);
-      const $v = mkBtn('Ver', 'guc-pdf-view');
-      const $r = mkBtn('Reemplazar', 'guc-pdf-replace');
-      const $d = mkBtn('Eliminar', 'guc-pdf-delete');
-      menu.append($v,$r,$d);
-      $('body').append(menu);
-      const off = $anchor.offset(); const h = $anchor.outerHeight();
-      menu.css({left: off.left, top: off.top + h + 6});
-      setTimeout(function(){
-        $(document).one('mousedown.gucPdfMenu', function(e){
-          if ($(e.target).closest('.guc-pdf-menu, .guc-pdf').length) return;
-          $('.guc-pdf-menu').remove();
-        });
-      }, 0);
-      return menu;
-    }
-
-    $(document).on('click', '.guc-pdf', function(){
-      const $btn = $(this);
-      const $row = $btn.closest('tr');
-      const rowId = $row.data('row-id'); if(!rowId) return;
-      let section = $btn.data('section');
-      if(!section){
-        const $wrap = $btn.closest('.guc-subtable-wrap');
-        const secKey = $wrap.data('section');
-        if (secKey === 'secretaria') section = $wrap.attr('data-bucket') || 'sec_general';
-        else section = (secKey === 'pre') ? 'pre' : 'arb';
-      }
-      const menu = buildPdfMenu($btn);
-
-      menu.off('click', '.guc-pdf-view').on('click', '.guc-pdf-view', function(){
-        // attempt to get current URL
-        $.post(GUC_CASOS.ajax, { action:'guc_get_section_row', nonce:GUC_CASOS.nonce, section, row_id: rowId }, function(res){
-          if (res && res.success && res.data && res.data.pdf_url){ window.open(res.data.pdf_url, '_blank'); }
-          else alert('No hay PDF para esta fila.');
-          $('.guc-pdf-menu').remove();
-        }, 'json').fail(function(){ alert('Error de conexión'); $('.guc-pdf-menu').remove(); });
-      });
-
-      menu.off('click', '.guc-pdf-replace').on('click', '.guc-pdf-replace', function(){
-        const $input = $('<input type="file" accept="application/pdf" style="display:none">').appendTo('body');
-        $input.on('change', function(){
-          if (!this.files || !this.files[0]) { $input.remove(); $('.guc-pdf-menu').remove(); return; }
-          const fd = new FormData();
-          fd.append('action','guc_upload_pdf'); fd.append('nonce', GUC_CASOS.nonce);
-          fd.append('section', section); fd.append('row_id', rowId); fd.append('file', this.files[0]);
-          $.ajax({ url: GUC_CASOS.ajax, type:'POST', data: fd, contentType:false, processData:false, dataType:'json' })
-          .done(function(res){
-            if(res && res.success){
-              // refresh only this wrap
-              const $wrap = $btn.closest('.guc-subtable-wrap');
-              renderSection($wrap);
-            } else alert(res?.data?.message || 'No se pudo subir el PDF');
-          }).fail(function(){ alert('Error de conexión'); })
-          .always(function(){ $input.remove(); $('.guc-pdf-menu').remove(); });
-        }).trigger('click');
-      });
-
-      menu.off('click', '.guc-pdf-delete').on('click', '.guc-pdf-delete', function(){
-        if(!confirm('¿Eliminar el PDF de esta fila?')) { $('.guc-pdf-menu').remove(); return; }
-        $.post(GUC_CASOS.ajax, { action:'guc_clear_pdf', nonce:GUC_CASOS.nonce, section, row_id: rowId }, function(res){
-          if (res && res.success){
-            const $wrap = $btn.closest('.guc-subtable-wrap');
-            renderSection($wrap);
-          } else alert(res?.data?.message || 'No se pudo eliminar el PDF');
-          $('.guc-pdf-menu').remove();
-        }, 'json').fail(function(){ alert('Error de conexión'); $('.guc-pdf-menu').remove(); });
-      });
-    });
-
-
     /* ==========================================================
      *  Carga inicial de tabla de casos
      * ========================================================== */

--- a/guc-casos.php
+++ b/guc-casos.php
@@ -1,14 +1,14 @@
 
 <?php
 /**
- * Plugin Name: GUC Casos (v1.6.0)
+ * Plugin Name: GUC Casos (v1.6.7)
  * Description: Gestión de Casos con subtables por sección y columna ACCIONES. case_type inmutable y un caso por usuario.
- * Version:     1.6.0
+ * Version:     1.6.7
  */
 if (!defined('ABSPATH')) exit;
 
 final class GUC_Casos_Compact {
-  const VERSION = '1.6.0';
+  const VERSION = '1.6.7';
   private static $inst = null;
   public static function instance(){ return self::$inst ?: self::$inst = new self(); }
 
@@ -31,10 +31,12 @@ final class GUC_Casos_Compact {
     $this->t_sec_general  = $wpdb->prefix.'guc_secretaria_general_actions';
 
     add_action('init', [$this,'assets']);
+    add_action('plugins_loaded', [$this,'maybe_upgrade_schema']);
     add_shortcode('gestion_casos', [$this,'shortcode']);
 
     $ax = [
       'guc_list_cases','guc_list_users','guc_create_case','guc_get_case','guc_update_case','guc_delete_case',
+      'guc_update_case_status',
       'guc_create_case_event','guc_secretaria_title','guc_list_section','guc_create_section_action',
       'guc_get_section_row','guc_update_section_row','guc_delete_section_row','guc_upload_pdf','guc_clear_pdf'
     ];
@@ -44,10 +46,40 @@ final class GUC_Casos_Compact {
     }
   }
 
+  public function maybe_upgrade_schema(){
+    global $wpdb;
+    $table = $this->t_cases;
+    if (!$table) return;
+    $columns = $wpdb->get_col("SHOW COLUMNS FROM `$table`");
+    if (!is_array($columns)) return;
+
+    if (!in_array('estado', $columns, true)) {
+      $wpdb->query("ALTER TABLE `$table` ADD `estado` varchar(50) DEFAULT '' AFTER `descripcion`");
+    }
+    if (!in_array('estado_fecha', $columns, true)) {
+      $wpdb->query("ALTER TABLE `$table` ADD `estado_fecha` datetime NULL DEFAULT NULL AFTER `estado`");
+    }
+  }
+
   function assets(){
     $base = plugin_dir_url(__FILE__);
-    wp_register_style ('guc-casos', $base.'assets/guc-casos.css', [], self::VERSION);
-    wp_register_script('guc-casos', $base.'assets/guc-casos.js', ['jquery'], self::VERSION, true);
+    $path = plugin_dir_path(__FILE__);
+
+    $css_ver = self::VERSION;
+    $js_ver  = self::VERSION;
+
+    $css_path = $path.'assets/guc-casos.css';
+    $js_path  = $path.'assets/guc-casos.js';
+
+    if (file_exists($css_path)) {
+      $css_ver .= '.'.filemtime($css_path);
+    }
+    if (file_exists($js_path)) {
+      $js_ver .= '.'.filemtime($js_path);
+    }
+
+    wp_register_style ('guc-casos', $base.'assets/guc-casos.css', [], $css_ver);
+    wp_register_script('guc-casos', $base.'assets/guc-casos.js', ['jquery'], $js_ver, true);
     wp_localize_script('guc-casos','GUC_CASOS',[
       'ajax'=>admin_url('admin-ajax.php'),
       'nonce'=>wp_create_nonce('guc_casos_nonce'),
@@ -60,7 +92,36 @@ final class GUC_Casos_Compact {
     <div id="guc-casos" class="guc-wrap">
       <div class="guc-header">
         <h2 class="guc-title">Gestión de Casos</h2>
-        <button id="guc-open-modal" class="guc-btn guc-btn-primary"><span class="guc-icon">＋</span>Nuevo caso</button>
+        <div class="guc-header-controls">
+          <form id="guc-search-form" class="guc-search" role="search">
+            <label class="guc-visually-hidden" for="guc-search-expediente">Buscar por expediente</label>
+            <input type="search" id="guc-search-expediente" name="expediente" placeholder="N° Expediente" autocomplete="off">
+            <button type="submit" class="guc-search-btn" aria-label="Buscar expediente">
+              <span class="guc-ico-mini guc-ico-search" aria-hidden="true"></span>
+            </button>
+          </form>
+          <div class="guc-filter" data-filter-wrapper data-filter-active="0">
+            <button type="button" id="guc-filter-toggle" class="guc-filter-toggle" aria-haspopup="true" aria-expanded="false">
+              <span class="guc-ico-mini guc-ico-filter" aria-hidden="true"></span>
+              <span class="guc-filter-text">Todos</span>
+            </button>
+            <div id="guc-filter-menu" class="guc-filter-menu" role="menu" hidden>
+              <button type="button" data-filter="" role="menuitemradio" aria-checked="true">
+                <span class="guc-filter-check" aria-hidden="true"></span>
+                <span class="guc-filter-label">Todos</span>
+              </button>
+              <button type="button" data-filter="TAR" role="menuitemradio" aria-checked="false">
+                <span class="guc-filter-check" aria-hidden="true"></span>
+                <span class="guc-filter-label">TAR</span>
+              </button>
+              <button type="button" data-filter="JPRD" role="menuitemradio" aria-checked="false">
+                <span class="guc-filter-check" aria-hidden="true"></span>
+                <span class="guc-filter-label">JPRD</span>
+              </button>
+            </div>
+          </div>
+          <button id="guc-open-modal" class="guc-btn guc-btn-primary"><span class="guc-icon">＋</span>Nuevo caso</button>
+        </div>
       </div>
       <div class="guc-card">
         <table class="guc-table">
@@ -78,7 +139,7 @@ final class GUC_Casos_Compact {
     </div>
 
     <!-- Modal crear/editar -->
-    <div id="guc-modal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div id="guc-casos-modal" role="dialog" aria-modal="true" aria-hidden="true">
       <div class="guc-modal-dialog">
         <div class="guc-modal-header">
           <h3 id="guc-modal-title">Crear nuevo caso</h3>
@@ -136,14 +197,14 @@ final class GUC_Casos_Compact {
           </form>
         </div>
         <div class="guc-modal-footer">
-          <button id="guc-cancel" class="guc-btn">Cancelar</button>
-          <button id="guc-save"   class="guc-btn guc-btn-primary">Guardar</button>
+          <button type="button" id="guc-cancel" class="guc-btn">Cancelar</button>
+          <button type="button" id="guc-save"   class="guc-btn guc-btn-primary">Guardar</button>
         </div>
       </div>
     </div>
 
     <!-- Modal iniciar/agregar acción -->
-    <div id="guc-modal-start" role="dialog" aria-modal="true" aria-hidden="true">
+    <div id="guc-casos-modal-start" role="dialog" aria-modal="true" aria-hidden="true">
       <div class="guc-modal-dialog">
         <div class="guc-modal-header">
           <h3>Registrar acción</h3>
@@ -166,14 +227,63 @@ final class GUC_Casos_Compact {
               <label>Motivo</label>
               <textarea name="motivo" required></textarea>
             </div>
+            <div class="guc-field guc-field-pdf guc-hidden" id="guc-action-pdf" aria-hidden="true" data-has-pdf="0">
+              <label>PDF</label>
+              <div class="guc-pdf-card">
+                <div class="guc-pdf-meta">
+                  <span class="guc-pdf-name" id="guc-action-pdf-name">Sin archivo adjunto</span>
+                  <a href="#" target="_blank" rel="noopener" class="guc-pdf-link" id="guc-action-pdf-open" hidden>Ver documento</a>
+                </div>
+                <div class="guc-pdf-buttons">
+                  <button type="button" class="guc-ico guc-ico-upload" id="guc-action-pdf-upload" aria-label="Subir o reemplazar PDF"></button>
+                  <button type="button" class="guc-ico guc-ico-del" id="guc-action-pdf-delete" aria-label="Eliminar PDF" disabled></button>
+                </div>
+              </div>
+            </div>
           </form>
         </div>
         <div class="guc-modal-footer">
-          <button id="guc-cancel-start" class="guc-btn">Cancelar</button>
-          <button id="guc-save-start" class="guc-btn guc-btn-primary">Guardar</button>
+          <button type="button" id="guc-cancel-start" class="guc-btn">Cancelar</button>
+          <button type="button" id="guc-save-start" class="guc-btn guc-btn-primary">Guardar</button>
+        </div>
         </div>
       </div>
     </div>
+
+    <!-- Modal estado del caso -->
+    <div id="guc-casos-modal-status" role="dialog" aria-modal="true" aria-hidden="true">
+      <div class="guc-modal-dialog">
+        <div class="guc-modal-header">
+          <h3>Estado del caso</h3>
+          <button type="button" class="guc-modal-close">✕</button>
+        </div>
+        <div class="guc-modal-body">
+          <form id="guc-form-status">
+            <input type="hidden" name="case_id">
+            <div class="guc-modal-status-grid">
+              <div class="guc-field">
+                <label>Estado</label>
+                <select name="estado" required>
+                  <option value="">-Selecciona un estado-</option>
+                  <option value="Inicio">Inicio</option>
+                  <option value="En proceso">En proceso</option>
+                  <option value="Terminado">Terminado</option>
+                </select>
+              </div>
+              <div class="guc-field">
+                <label>Fecha y Hora</label>
+                <input type="datetime-local" name="estado_fecha">
+              </div>
+            </div>
+          </form>
+        </div>
+        <div class="guc-modal-footer">
+          <button type="button" id="guc-cancel-status" class="guc-btn">Cancelar</button>
+          <button type="button" id="guc-save-status" class="guc-btn guc-btn-primary">Guardar</button>
+        </div>
+      </div>
+    </div>
+
     <?php
     return ob_get_clean();
   }
@@ -192,10 +302,49 @@ final class GUC_Casos_Compact {
     return null;
   }
 
+  private function case_has_actions($case_id){
+    global $wpdb;
+    $case_id = intval($case_id);
+    if(!$case_id) return false;
+    $tables = [$this->t_events, $this->t_pre, $this->t_arb, $this->t_sec_arbitral, $this->t_sec_general];
+    foreach($tables as $t){
+      if(!$t) continue;
+      $count = intval($wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM `$t` WHERE case_id=%d", $case_id)));
+      if($count > 0) return true;
+    }
+    return false;
+  }
+
   // ====== AJAX ======
   public function guc_list_cases(){
     $this->check_nonce(); global $wpdb;
-    $rows = $wpdb->get_results("SELECT c.*, u.username FROM {$this->t_cases} c LEFT JOIN {$this->t_users} u ON u.id=c.user_id ORDER BY c.id DESC");
+    $search = isset($_POST['search']) ? sanitize_text_field(wp_unslash($_POST['search'])) : '';
+    $filter = isset($_POST['filter']) ? sanitize_text_field(wp_unslash($_POST['filter'])) : '';
+
+    $conditions = [];
+    $params = [];
+    if ($filter === 'TAR' || $filter === 'JPRD') {
+      $conditions[] = 'c.case_type = %s';
+      $params[] = $filter;
+    }
+
+    $order = ' ORDER BY c.id DESC';
+    if ($search !== '') {
+      $like = '%' . $wpdb->esc_like($search) . '%';
+      $order = ' ORDER BY CASE WHEN c.expediente LIKE %s THEN 0 ELSE 1 END, c.id DESC';
+      $params[] = $like;
+    }
+
+    $sql = "SELECT c.*, u.username FROM {$this->t_cases} c LEFT JOIN {$this->t_users} u ON u.id=c.user_id";
+    if ($conditions) {
+      $sql .= ' WHERE ' . implode(' AND ', $conditions);
+    }
+    $sql .= $order;
+    if ($params) {
+      $sql = $wpdb->prepare($sql, $params);
+    }
+
+    $rows = $wpdb->get_results($sql);
     ob_start();
     if (!$rows){ echo '<tr><td colspan="6" class="guc-empty">Sin casos.</td></tr>'; }
     else foreach($rows as $r){
@@ -203,18 +352,21 @@ final class GUC_Casos_Compact {
       $ent = $this->html_esc($r->entidad);
       $nom = $this->html_esc($r->nomenclature);
       $usr = $this->html_esc($r->username);
-      $has_events = intval($wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$this->t_events} WHERE case_id=%d",$r->id))) > 0;
-      $hist_btn = $has_events ? 'Agregar acción' : 'Iniciar caso';
+      $has_actions = $this->case_has_actions($r->id);
+      $hist_btn = $has_actions ? 'Agregar acción' : 'Iniciar caso';
 
-      echo '<tr data-id="'.intval($r->id).'">';
+      $match = ($search !== '' && stripos((string) $r->expediente, $search) !== false);
+      $match_attr = $match ? ' data-search-match="1"' : '';
+      echo '<tr data-id="'.intval($r->id).'" data-has-actions="'.($has_actions ? '1' : '0').'"'.$match_attr.'>';
       echo "<td>{$exp}</td><td>{$ent}</td><td>{$nom}</td><td>{$usr}</td>";
       echo '<td><button class="guc-btn guc-btn-secondary guc-start" data-id="'.intval($r->id).'">'.$hist_btn.'</button></td>';
       echo '<td>';
-      echo ' <div class="guc-actions" style="display:inline-block">';
-      echo '   <button class="guc-act guc-view" data-id="'.intval($r->id).'">👁</button>';
-      echo '   <button class="guc-act guc-edit" data-id="'.intval($r->id).'">✎</button>';
-      echo '   <button class="guc-act guc-del"  data-id="'.intval($r->id).'" onclick="return confirm(\'¿Eliminar este caso?\')">🗑</button>';
-      echo ' </div>';
+      echo '  <div class="guc-actions">';
+      echo '    <button type="button" class="guc-act guc-status" data-id="'.intval($r->id).'" aria-label="Actualizar estado del caso"><span class="guc-ico guc-ico-gear" aria-hidden="true"></span></button>';
+      echo '    <button type="button" class="guc-act guc-view" data-id="'.intval($r->id).'" aria-label="Ver caso"><span class="guc-ico guc-ico-view" aria-hidden="true"></span></button>';
+      echo '    <button type="button" class="guc-act guc-edit" data-id="'.intval($r->id).'" aria-label="Editar caso"><span class="guc-ico guc-ico-edit" aria-hidden="true"></span></button>';
+      echo '    <button type="button" class="guc-act guc-del"  data-id="'.intval($r->id).'" aria-label="Eliminar caso" onclick="return confirm(\'¿Eliminar este caso?\')"><span class="guc-ico guc-ico-del" aria-hidden="true"></span></button>';
+      echo '  </div>';
       echo '</td></tr>';
     }
     $html = ob_get_clean();
@@ -223,7 +375,16 @@ final class GUC_Casos_Compact {
 
   public function guc_list_users(){
     $this->check_nonce(); global $wpdb;
-    $rows = $wpdb->get_results("SELECT u.* FROM {$this->t_users} u WHERE NOT EXISTS (SELECT 1 FROM {$this->t_cases} c WHERE c.user_id=u.id) ORDER BY u.id DESC");
+    $include_id = intval($_POST['include_id'] ?? 0);
+    if ($include_id) {
+      $sql = $wpdb->prepare(
+        "SELECT u.* FROM {$this->t_users} u WHERE NOT EXISTS (SELECT 1 FROM {$this->t_cases} c WHERE c.user_id=u.id) OR u.id=%d ORDER BY u.id DESC",
+        $include_id
+      );
+    } else {
+      $sql = "SELECT u.* FROM {$this->t_users} u WHERE NOT EXISTS (SELECT 1 FROM {$this->t_cases} c WHERE c.user_id=u.id) ORDER BY u.id DESC";
+    }
+    $rows = $wpdb->get_results($sql);
     $out = [];
     foreach($rows as $r){
       $out[] = ['id'=>intval($r->id),'username'=>$r->username,'entity'=>$r->entity,'expediente'=>$r->expediente];
@@ -252,6 +413,8 @@ final class GUC_Casos_Compact {
       'entidad'      => $u->entity,
       'objeto'       => sanitize_text_field($data['objeto'] ?? ''),
       'descripcion'  => sanitize_textarea_field($data['descripcion'] ?? ''),
+      'estado'       => '',
+      'estado_fecha' => null,
       'user_id'      => $user_id,
       'username'     => $u->username,
       'case_type'    => sanitize_text_field($data['case_type'] ?? ''),
@@ -300,6 +463,41 @@ final class GUC_Casos_Compact {
     $ok = $wpdb->update($this->t_cases,$upd,['id'=>$id]);
     if($ok===false) wp_send_json_error(['message'=>'No se pudo actualizar']);
     wp_send_json_success(['id'=>$id]);
+  }
+
+  public function guc_update_case_status(){
+    $this->check_nonce(); global $wpdb;
+    $data = isset($_POST['data']) ? (array) $_POST['data'] : [];
+    $id = intval($data['case_id'] ?? 0);
+    if(!$id) wp_send_json_error(['message'=>'ID inválido']);
+
+    $estado = sanitize_text_field($data['estado'] ?? '');
+    $allowed = ['Inicio','En proceso','Terminado'];
+    if(!$estado || !in_array($estado, $allowed, true)){
+      wp_send_json_error(['message'=>'Selecciona un estado válido']);
+    }
+
+    $exists = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$this->t_cases} WHERE id=%d", $id));
+    if(!$exists){
+      wp_send_json_error(['message'=>'Caso no encontrado']);
+    }
+
+    $fecha_in = sanitize_text_field($data['estado_fecha'] ?? '');
+    $fecha_db = null;
+    if($fecha_in){
+      $candidate = str_replace('T',' ',$fecha_in);
+      $ts = strtotime($candidate);
+      if($ts){
+        $fecha_db = date('Y-m-d H:i:s', $ts);
+      }
+    }
+
+    $upd = ['estado'=>$estado, 'estado_fecha'=>$fecha_db];
+
+    $ok = $wpdb->update($this->t_cases, $upd, ['id'=>$id]);
+    if($ok===false) wp_send_json_error(['message'=>'No se pudo guardar el estado']);
+
+    wp_send_json_success(['id'=>$id,'estado'=>$estado,'estado_fecha'=>$upd['estado_fecha']]);
   }
 
   public function guc_delete_case(){
@@ -376,18 +574,22 @@ final class GUC_Casos_Compact {
         $sit   = $this->html_esc($r->situacion);
         $mot   = $this->html_esc($r->motivo);
         $pdf   = ($pdf_col && !empty($r->$pdf_col)) ? esc_url($r->$pdf_col) : '';
-        echo '<tr data-row-id="'.intval($r->id).'">';
+        $row_id = intval($r->id);
+        $case_attr = ' data-case-id="'.intval($case_id).'"';
+        echo '<tr data-row-id="'.$row_id.'"'.$case_attr.'>';
         echo '<td>'.$i++.'</td><td>'.$sit.'</td><td>'.$fecha.'</td><td>'.$mot.'</td>';
         echo '<td class="guc-actions">';
-        if($pdf){
-          echo '<a class="guc-ico guc-ico-pdf" target="_blank" rel="noopener" href="'.$pdf.'" title="Ver PDF">📄</a>';
-          echo ' <button class="guc-ico guc-ico-replace guc-upload" data-section="'.esc_attr($section).'" title="Reemplazar PDF">⤴</button>';
-          echo ' <button class="guc-ico guc-ico-clear guc-clear-pdf" data-section="'.esc_attr($section).'" title="Quitar PDF">✕</button>';
-        }else{
-          echo '<button class="guc-ico guc-ico-upload guc-upload" data-section="'.esc_attr($section).'" title="Subir PDF">⤴</button>';
+        $has_pdf_attr = $pdf ? ' data-has-pdf="1"' : ' data-has-pdf="0"';
+        $pdf_btn_classes = 'guc-ico guc-ico-upload guc-upload'.($pdf ? ' has-pdf' : '');
+        $pdf_label = $pdf ? 'Reemplazar PDF' : 'Subir PDF';
+        $button = '<button type="button" class="'.esc_attr($pdf_btn_classes).'" data-section="'.esc_attr($section).'"'.$has_pdf_attr.' aria-label="'.esc_attr($pdf_label).'"';
+        if ($pdf) {
+          $button .= ' data-pdf-url="'.$pdf.'"';
         }
-        echo ' <button class="guc-ico guc-ico-edit guc-row-edit" data-section="'.esc_attr($section).'" title="Editar">✎</button>';
-        echo ' <button class="guc-ico guc-ico-del guc-row-del" data-section="'.esc_attr($section).'" title="Eliminar">🗑</button>';
+        $button .= '></button>';
+        echo $button;
+        echo ' <button type="button" class="guc-ico guc-ico-edit guc-row-edit" data-section="'.esc_attr($section).'" aria-label="Editar acción"></button>';
+        echo ' <button type="button" class="guc-ico guc-ico-del guc-row-del" data-section="'.esc_attr($section).'" aria-label="Eliminar acción"></button>';
         echo '</td></tr>';
       }
     }


### PR DESCRIPTION
## Summary
- reset the expediente search so clearing the field or reloading restores the default case order instead of persisting previous filters
- scope modal markup, classes, and styling to Gestion de Casos specific IDs/body class to avoid clashes with other plugins and update the plugin version to 1.6.7
- adjust the JavaScript persistence logic to keep only accordion state while leaving search/filter blank when not in use

## Testing
- php -l guc-casos.php

------
https://chatgpt.com/codex/tasks/task_e_68e54d3db4d8832a94d3b988ad204c43